### PR TITLE
Add diff stats and expandable PR description preview

### DIFF
--- a/docs/marketing/competitive-analysis.md
+++ b/docs/marketing/competitive-analysis.md
@@ -1,0 +1,137 @@
+# Competitive Analysis — PR Radar
+
+Last updated: 2026-04-19
+
+## Overview
+
+PR Radar is a free, open-source Chrome extension (Manifest V3) that provides a unified PR dashboard for GitHub, GitLab, and Bitbucket. This document tracks competing tools and PR Radar's positioning.
+
+## Competitors
+
+### Tier 1: Direct Competitors (Multi-Platform PR Dashboards)
+
+**GitKraken Launchpad** — The closest competitor. Supports GitHub, GitLab, Bitbucket, and Azure DevOps. The browser extension is free but the full Launchpad dashboard requires a Teams plan at $8.95/user/month. Does not offer sound/desktop notifications from the extension, CI badge status in the popup, or unresolved comment counts.
+
+**Pullwalla** — Supports GitHub and Bitbucket (no GitLab). Native macOS/iOS app, not a Chrome extension. Notifications are a paid feature. No CI status display, no unresolved comment counts, no deployment status.
+
+**CatLight** — Supports GitHub, GitLab, and Azure DevOps (no Bitbucket). Desktop tray app. Free for small teams, paid for larger ones. Focused on CI/build monitoring with a "who broke the build" feature. No unresolved comments, deployment status, or PR triage features.
+
+### Tier 2: GitHub-Only PR Tools
+
+**PR Monitor** — Free, open source Chrome extension. Closest UX match (popup with PR list) but GitHub-only. No CI status badges, no unresolved comment counts, no deployment status, no sound alerts.
+
+**PR Hub** — Free Chrome extension. Similar tab-based UI but GitHub-only. Has CI status and comment counts but lacks multi-platform support, deployment status, sound alerts, and merge capability.
+
+**Notifier for GitHub** — By Sindre Sorhus. Free, open source. Shows unread notification count badge only — no PR dashboard.
+
+**Refined GitHub** — Free, open source. Enhances GitHub's own web UI with 200+ improvements. Complementary tool, not a competitor — users could use both.
+
+**Graphite** — GitHub-only. Focused on stacked PRs, AI code review, and merge queues. Free tier is limited; paid plans start at $20/user/month. Web app + CLI + VS Code extension, not a Chrome extension. Different use case entirely.
+
+### Tier 3: Notification & Monitoring Tools
+
+**Gitify** — Free, open source. Desktop menu bar app for GitHub notifications. Not a PR dashboard.
+
+**DevHub** — GitHub-only. TweetDeck-like multi-column layout for notifications, issues, and activity. Different UX paradigm.
+
+**Octobox** — GitHub-only web app. Enhanced notification inbox. Free for open source, paid for private repos.
+
+### Tier 4: Engineering Metrics Platforms
+
+**LinearB / Haystack / Swarmia / Axolo** — Enterprise engineering metrics platforms. Team/manager focused. Paid. Much broader scope than PR monitoring.
+
+## Feature Comparison
+
+| Feature | PR Radar | GitKraken Launchpad | PR Monitor | PR Hub | Pullwalla | CatLight | Gitify | Graphite | CodeStream |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **Platform Support** | | | | | | | | | |
+| GitHub | Y | Y | Y | Y | Y | Y | Y | Y | Y |
+| GitLab | Y | Y | - | - | - | Y | - | - | Y |
+| Bitbucket | Y | Y | - | - | Y | - | - | - | Y |
+| Azure DevOps | - | Y | - | - | - | Y | - | - | - |
+| Self-hosted instances | - | Y | - | - | - | Y | Y | - | Y |
+| **Form Factor** | | | | | | | | | |
+| Chrome extension popup | Y | Y | Y | Y | - | - | - | - | - |
+| Web app | - | Y | - | - | - | - | - | Y | - |
+| Desktop app | - | Y | - | - | Y | Y | Y | - | - |
+| Mobile app | - | - | - | - | Y | - | Y | Y | - |
+| IDE extension | - | Y | - | - | - | - | - | Y | Y |
+| **Pricing** | | | | | | | | | |
+| Fully free | Y | - | Y | Y | - | - | Y | - | Y |
+| Open source | Y | - | Y | - | - | - | Y | - | - |
+| **PR Management** | | | | | | | | | |
+| My PRs / Review / All tabs | Y | Y | Y | Y | Y | - | - | Y | - |
+| Merge from dashboard | Y | - | - | - | $ | - | - | Y | Y |
+| Draft PR indicator | Y | Y | - | - | - | - | - | Y | - |
+| Conflict detection | Y | - | - | - | - | - | - | Y | - |
+| Stale PR detection | Y | - | - | - | - | - | - | - | - |
+| Pinned/favorite repos | Y | Y | - | - | - | - | - | - | - |
+| Search/filter PRs | Y | Y | - | - | Y | - | Y | Y | - |
+| Urgency triage chips | Y | - | - | - | - | - | - | - | - |
+| PR description preview | Y | Y | - | - | Y | - | - | Y | Y |
+| Diff stats (+/- lines) | Y | Y | Y | - | - | - | - | Y | Y |
+| Pending reviewers badge | Y | - | - | - | - | - | - | - | - |
+| Stacked PRs | - | - | - | - | - | - | - | Y | - |
+| In-app code review | - | - | - | - | $ | - | - | Y | Y |
+| Merge queue | - | - | - | - | - | - | - | Y | - |
+| AI code review | - | - | - | - | - | - | - | Y | - |
+| **CI & Status** | | | | | | | | | |
+| CI status badges | Y | Y | Y | Y | - | Y | - | Y | - |
+| Unresolved comment count | Y | - | - | - | - | - | - | - | Y |
+| Deployment status | Y | - | - | - | - | - | - | - | - |
+| Review state tracking | Y | Y | Y | Y | - | - | - | Y | Y |
+| Who broke the build | Y | - | - | - | - | Y | - | - | - |
+| **Notifications** | | | | | | | | | |
+| Desktop notifications | Y | - | Y | - | $ | Y | Y | Y | - |
+| Sound alerts | Y | - | - | - | - | - | - | - | - |
+| Badge count (extension) | Y | - | Y | - | - | - | Y | - | - |
+| Slack integration | - | Y | - | - | - | - | - | Y | Y |
+| Email digest | - | - | - | - | - | - | - | Y | - |
+| **Integrations** | | | | | | | | | |
+| Jira / issue tracker | - | Y | - | - | - | - | - | Y | Y |
+| Open in IDE | - | Y | - | - | - | - | - | Y | Y |
+| Team/org management | - | Y | Y | - | - | Y | - | Y | Y |
+| **Privacy & Architecture** | | | | | | | | | |
+| No backend required | Y | - | Y | Y | - | - | Y | - | - |
+| PAT-only (no OAuth) | Y | - | - | - | - | - | - | - | - |
+| Data stays local | Y | - | Y | Y | - | - | Y | - | - |
+
+`Y` = supported, `-` = not supported, `$` = paid feature
+
+## Scorecard
+
+| Tool | Features | Notable Gaps |
+|---|---|---|
+| **PR Radar** | 28 | Self-hosted, Azure DevOps, Slack, IDE, Jira |
+| **GitKraken** | 20 | Paid, no merge, no unresolved counts, no deployment status |
+| **Graphite** | 18 | GitHub-only, paid, no extension popup |
+| **CodeStream** | 14 | No popup, no notifications, no badge count |
+| **PR Monitor** | 10 | GitHub-only |
+| **Gitify** | 9 | GitHub-only, notifications only |
+| **CatLight** | 8 | Paid, no Bitbucket |
+| **Pullwalla** | 6 | No GitLab, key features are paid |
+| **PR Hub** | 5 | GitHub-only, minimal features |
+
+## PR Radar's Unique Positioning
+
+PR Radar is the only tool that combines all of these in a **free, open-source Chrome extension**:
+
+1. **All 3 major platforms** (GitHub + GitLab + Bitbucket)
+2. **Unresolved comment counts** via GitHub GraphQL
+3. **Deployment status** tracking
+4. **Sound alerts**
+5. **Urgency triage chips**
+6. **Merge from popup** across all platforms
+7. **Zero backend / PAT-only** — data stays local
+8. **Pending reviewers** badge
+9. **Who broke the build** in CI failure tooltip
+
+## Planned Features
+
+Tracked as GitHub issues:
+
+- [#1](https://github.com/deployhq/pr-radar/issues/1) — Self-hosted instance support (GHE, GitLab self-managed, Bitbucket Server)
+- [#2](https://github.com/deployhq/pr-radar/issues/2) — Slack integration for PR notifications
+- [#3](https://github.com/deployhq/pr-radar/issues/3) — Azure DevOps support
+- [#4](https://github.com/deployhq/pr-radar/issues/4) — Open in IDE (VS Code / JetBrains)
+- [#5](https://github.com/deployhq/pr-radar/issues/5) — Jira / issue tracker link detection

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pr-radar",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pr-radar",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "react": "^18.3.1",

--- a/src/popup/components/CIBadge.tsx
+++ b/src/popup/components/CIBadge.tsx
@@ -25,16 +25,17 @@ interface CIBadgeProps {
 export default function CIBadge({ status, failedChecks }: CIBadgeProps) {
   if (status === 'unknown') return null;
 
+  const label = CI_STATUS_LABELS[status];
   const tooltip = status === 'failed' && failedChecks && failedChecks.length > 0
-    ? `Failed: ${failedChecks.join(', ')}`
-    : undefined;
+    ? `${label}: ${failedChecks.join(', ')}`
+    : label;
 
   return (
     <span
       className={`text-[10px] px-1.5 py-0.5 rounded-full font-semibold flex items-center gap-1 ${BADGE_STYLES[status]}`}
       title={tooltip}
     >
-      {BADGE_ICONS[status]} {CI_STATUS_LABELS[status]}
+      {BADGE_ICONS[status]}
     </span>
   );
 }

--- a/src/popup/components/CIBadge.tsx
+++ b/src/popup/components/CIBadge.tsx
@@ -20,6 +20,7 @@ const BADGE_ICONS: Record<CIStatus, string> = {
 interface CIBadgeProps {
   status: CIStatus;
   failedChecks?: string[];
+  author?: string;
   durationMs?: number;
 }
 
@@ -33,14 +34,16 @@ function formatDuration(ms: number): string {
   return remainMinutes > 0 ? `${hours}h${remainMinutes}m` : `${hours}h`;
 }
 
-export default function CIBadge({ status, failedChecks, durationMs }: CIBadgeProps) {
+export default function CIBadge({ status, failedChecks, author, durationMs }: CIBadgeProps) {
   if (status === 'unknown') return null;
 
   const label = CI_STATUS_LABELS[status];
   const durationLabel = durationMs ? ` (${formatDuration(durationMs)})` : '';
-  const tooltip = status === 'failed' && failedChecks && failedChecks.length > 0
-    ? `${label}${durationLabel}: ${failedChecks.join(', ')}`
-    : `${label}${durationLabel}`;
+  const brokenBy = status === 'failed' && author ? ` — broken by @${author}` : '';
+  const failedList = status === 'failed' && failedChecks && failedChecks.length > 0
+    ? `: ${failedChecks.join(', ')}`
+    : '';
+  const tooltip = `${label}${durationLabel}${failedList}${brokenBy}`;
 
   return (
     <span

--- a/src/popup/components/CIBadge.tsx
+++ b/src/popup/components/CIBadge.tsx
@@ -20,15 +20,27 @@ const BADGE_ICONS: Record<CIStatus, string> = {
 interface CIBadgeProps {
   status: CIStatus;
   failedChecks?: string[];
+  durationMs?: number;
 }
 
-export default function CIBadge({ status, failedChecks }: CIBadgeProps) {
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const minutes = Math.floor(totalSeconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const remainMinutes = minutes % 60;
+  return remainMinutes > 0 ? `${hours}h${remainMinutes}m` : `${hours}h`;
+}
+
+export default function CIBadge({ status, failedChecks, durationMs }: CIBadgeProps) {
   if (status === 'unknown') return null;
 
   const label = CI_STATUS_LABELS[status];
+  const durationLabel = durationMs ? ` (${formatDuration(durationMs)})` : '';
   const tooltip = status === 'failed' && failedChecks && failedChecks.length > 0
-    ? `${label}: ${failedChecks.join(', ')}`
-    : label;
+    ? `${label}${durationLabel}: ${failedChecks.join(', ')}`
+    : `${label}${durationLabel}`;
 
   return (
     <span
@@ -36,6 +48,9 @@ export default function CIBadge({ status, failedChecks }: CIBadgeProps) {
       title={tooltip}
     >
       {BADGE_ICONS[status]}
+      {durationMs !== undefined && (
+        <span className="opacity-80">{formatDuration(durationMs)}</span>
+      )}
     </span>
   );
 }

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -203,7 +203,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
         <div className="flex items-center gap-2 mt-1.5 ml-[30px] flex-wrap">
           {pr.isDraft && <Badge className="bg-gray-800 text-gray-500">Draft</Badge>}
 
-          <CIBadge status={pr.ciStatus} failedChecks={pr.ciFailedChecks} durationMs={pr.ciDurationMs} />
+          <CIBadge status={pr.ciStatus} failedChecks={pr.ciFailedChecks} author={pr.author} durationMs={pr.ciDurationMs} />
 
           {pr.approvalCount > 0 && (
             <span title={pr.approvedBy ? `Approved by: ${pr.approvedBy.join(', ')}` : undefined}>
@@ -216,7 +216,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
           {pr.reviewStatus === 'changes_requested' && (
             <span title={pr.changesRequestedBy ? `Changes requested by: ${pr.changesRequestedBy.join(', ')}` : undefined}>
               <Badge className="bg-red-900/50 text-red-400">
-                &#x21BB; Changes requested
+                &#x21BB;
               </Badge>
             </span>
           )}

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -207,7 +207,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
           {pr.approvalCount > 0 && (
             <span title={pr.approvedBy ? `Approved by: ${pr.approvedBy.join(', ')}` : undefined}>
               <Badge className="bg-emerald-900/50 text-emerald-400">
-                &#10003; {pr.approvalCount} approved
+                &#x1F464; {pr.approvalCount}
               </Badge>
             </span>
           )}
@@ -223,7 +223,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
           {pr.unresolvedCommentCount > 0 && (
             <span title={pr.unresolvedCommentAuthors ? `Unresolved from: ${pr.unresolvedCommentAuthors.join(', ')}` : undefined}>
               <Badge className="bg-gray-800 text-amber-400">
-                &#x1F4AC; {pr.unresolvedCommentCount} unresolved
+                &#x1F4AC; {pr.unresolvedCommentCount}
               </Badge>
             </span>
           )}
@@ -231,7 +231,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
           {pr.pendingReviewers && pr.pendingReviewers.length > 0 && (
             <span title={`Pending review from: ${pr.pendingReviewers.join(', ')}`}>
               <Badge className="bg-blue-900/50 text-blue-400">
-                &#x23F3; {pr.pendingReviewers.length} reviewing
+                &#x23F3; {pr.pendingReviewers.length}
               </Badge>
             </span>
           )}

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -203,7 +203,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
         <div className="flex items-center gap-2 mt-1.5 ml-[30px] flex-wrap">
           {pr.isDraft && <Badge className="bg-gray-800 text-gray-500">Draft</Badge>}
 
-          <CIBadge status={pr.ciStatus} failedChecks={pr.ciFailedChecks} />
+          <CIBadge status={pr.ciStatus} failedChecks={pr.ciFailedChecks} durationMs={pr.ciDurationMs} />
 
           {pr.approvalCount > 0 && (
             <span title={pr.approvedBy ? `Approved by: ${pr.approvedBy.join(', ')}` : undefined}>

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -16,6 +16,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
   const [branchState, setBranchState] = useState<'idle' | 'confirm' | 'deleting' | 'deleted' | 'error'>('idle');
   const [branchError, setBranchError] = useState('');
   const [expanded, setExpanded] = useState(false);
+  const description = pr.description?.trim();
   const timeAgo = getTimeAgo(pr.updatedAt);
   const isStale = stalePRDays > 0 && (Date.now() - new Date(pr.updatedAt).getTime()) > stalePRDays * 86400000;
   const isDimmed = (pr.hasReviewed && !pr.isAuthor) || isStale || pr.isBot || pr.isMerged || pr.isDraft;
@@ -289,7 +290,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
         )}
       </a>
 
-      {pr.description && (
+      {description && (
         <div className="ml-[30px] mt-1">
           <button
             onClick={() => setExpanded(!expanded)}
@@ -299,7 +300,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
           </button>
           {expanded && (
             <div className="mt-1 text-[11px] text-gray-400 leading-relaxed whitespace-pre-wrap break-words max-h-[120px] overflow-y-auto pr-2">
-              {pr.description.length > 500 ? `${pr.description.slice(0, 500)}…` : pr.description}
+              {description.length > 500 ? `${description.slice(0, 500)}…` : description}
             </div>
           )}
         </div>

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -15,6 +15,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
   const [mergeError, setMergeError] = useState('');
   const [branchState, setBranchState] = useState<'idle' | 'confirm' | 'deleting' | 'deleted' | 'error'>('idle');
   const [branchError, setBranchError] = useState('');
+  const [expanded, setExpanded] = useState(false);
   const timeAgo = getTimeAgo(pr.updatedAt);
   const isStale = stalePRDays > 0 && (Date.now() - new Date(pr.updatedAt).getTime()) > stalePRDays * 86400000;
   const isDimmed = (pr.hasReviewed && !pr.isAuthor) || isStale || pr.isBot || pr.isMerged || pr.isDraft;
@@ -251,6 +252,14 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
             </Badge>
           )}
 
+          {(pr.additions !== undefined || pr.deletions !== undefined) && (
+            <Badge className="bg-gray-800 text-gray-400">
+              <span className="text-emerald-400">+{pr.additions ?? 0}</span>
+              {' '}
+              <span className="text-red-400">-{pr.deletions ?? 0}</span>
+            </Badge>
+          )}
+
           <span
             className="text-[10px] text-gray-600 ml-auto"
             title={[
@@ -279,6 +288,22 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged }: PRItemProp
           </div>
         )}
       </a>
+
+      {pr.description && (
+        <div className="ml-[30px] mt-1">
+          <button
+            onClick={() => setExpanded(!expanded)}
+            className="text-[10px] text-gray-500 hover:text-gray-300 transition-colors cursor-pointer"
+          >
+            {expanded ? '\u25BE Hide description' : '\u25B8 Show description'}
+          </button>
+          {expanded && (
+            <div className="mt-1 text-[11px] text-gray-400 leading-relaxed whitespace-pre-wrap break-words max-h-[120px] overflow-y-auto pr-2">
+              {pr.description.length > 500 ? `${pr.description.slice(0, 500)}…` : pr.description}
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -41,6 +41,7 @@ interface BBUser {
 interface BBPullRequest {
   id: number;
   title: string;
+  description: string;
   state: string;
   links: { html: { href: string } };
   author: BBUser;
@@ -153,9 +154,10 @@ async function hydratePR(
   pr: BBPullRequest,
   username: string,
 ): Promise<PullRequest> {
-  const [ciStatus, comments] = await Promise.all([
+  const [ciStatus, comments, diffStats] = await Promise.all([
     fetchCIStatus(token, repoFullName, pr),
     fetchComments(token, repoFullName, pr.id),
+    fetchDiffStats(token, repoFullName, pr.id),
   ]);
 
   const reviewStatus = deriveBBReviewStatus(pr.participants);
@@ -197,6 +199,9 @@ async function hydratePR(
     changesRequestedBy: changesRequestedBy.length > 0 ? changesRequestedBy : undefined,
     unresolvedCommentCount,
     unresolvedCommentAuthors: unresolvedCommentAuthors.length > 0 ? unresolvedCommentAuthors : undefined,
+    additions: diffStats.additions || undefined,
+    deletions: diffStats.deletions || undefined,
+    description: pr.description || undefined,
     hasConflicts: false, // Would need separate merge check
     isAuthor: pr.author.nickname === username,
     isBot: false,
@@ -205,6 +210,28 @@ async function hydratePR(
     pendingReviewers: pendingReviewers.length > 0 ? pendingReviewers : undefined,
     headSha: pr.source.commit?.hash,
   };
+}
+
+async function fetchDiffStats(
+  token: string,
+  repoFullName: string,
+  prId: number,
+): Promise<{ additions: number; deletions: number }> {
+  try {
+    const result = await bbFetch<{ values: { lines_added: number; lines_removed: number }[] }>(
+      `/repositories/${repoFullName}/pullrequests/${prId}/diffstat`,
+      token,
+    );
+    let additions = 0;
+    let deletions = 0;
+    for (const file of result.values) {
+      additions += file.lines_added;
+      deletions += file.lines_removed;
+    }
+    return { additions, deletions };
+  } catch {
+    return { additions: 0, deletions: 0 };
+  }
 }
 
 async function fetchCIStatus(token: string, repoFullName: string, pr: BBPullRequest): Promise<CIStatus> {

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -221,8 +221,9 @@ async function fetchDiffStats(
 ): Promise<{ additions: number; deletions: number }> {
   try {
     const files = await bbFetchPaginated<{ lines_added: number; lines_removed: number }>(
-      `/repositories/${repoFullName}/pullrequests/${prId}/diffstat`,
+      `/repositories/${repoFullName}/pullrequests/${prId}/diffstat?pagelen=100`,
       token,
+      100,
     );
     let additions = 0;
     let deletions = 0;

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -57,6 +57,7 @@ interface BBPullRequest {
 
 interface BBPipelineStatus {
   state: { name: string; result?: { name: string } };
+  duration_in_seconds?: number;
 }
 
 interface BBComment {
@@ -154,7 +155,7 @@ async function hydratePR(
   pr: BBPullRequest,
   username: string,
 ): Promise<PullRequest> {
-  const [ciStatus, comments, diffStats] = await Promise.all([
+  const [ciResult, comments, diffStats] = await Promise.all([
     fetchCIStatus(token, repoFullName, pr),
     fetchComments(token, repoFullName, pr.id),
     fetchDiffStats(token, repoFullName, pr.id),
@@ -193,7 +194,8 @@ async function hydratePR(
     isDraft: false, // Bitbucket doesn't have draft PRs
     createdAt: pr.created_on,
     updatedAt: pr.updated_on,
-    ciStatus,
+    ciStatus: ciResult.status,
+    ciDurationMs: ciResult.durationMs,
     reviewStatus,
     approvalCount,
     changesRequestedBy: changesRequestedBy.length > 0 ? changesRequestedBy : undefined,
@@ -234,28 +236,34 @@ async function fetchDiffStats(
   }
 }
 
-async function fetchCIStatus(token: string, repoFullName: string, pr: BBPullRequest): Promise<CIStatus> {
+interface BBCIResult {
+  status: CIStatus;
+  durationMs?: number;
+}
+
+async function fetchCIStatus(token: string, repoFullName: string, pr: BBPullRequest): Promise<BBCIResult> {
   try {
     const result = await bbFetch<{ values: BBPipelineStatus[] }>(
       `/repositories/${repoFullName}/pipelines/?sort=-created_on&pagelen=1&target.branch=${pr.source.branch.name}`,
       token,
     );
 
-    if (!result.values.length) return 'unknown';
+    if (!result.values.length) return { status: 'unknown' };
     const pipeline = result.values[0];
+    const durationMs = pipeline.duration_in_seconds ? pipeline.duration_in_seconds * 1000 : undefined;
 
     switch (pipeline.state.name) {
       case 'COMPLETED':
-        return pipeline.state.result?.name === 'SUCCESSFUL' ? 'passed' : 'failed';
+        return { status: pipeline.state.result?.name === 'SUCCESSFUL' ? 'passed' : 'failed', durationMs };
       case 'IN_PROGRESS': case 'RUNNING':
-        return 'running';
+        return { status: 'running', durationMs };
       case 'PENDING':
-        return 'pending';
+        return { status: 'pending', durationMs };
       default:
-        return 'unknown';
+        return { status: 'unknown', durationMs };
     }
   } catch {
-    return 'unknown';
+    return { status: 'unknown' };
   }
 }
 

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -218,13 +218,13 @@ async function fetchDiffStats(
   prId: number,
 ): Promise<{ additions: number; deletions: number }> {
   try {
-    const result = await bbFetch<{ values: { lines_added: number; lines_removed: number }[] }>(
+    const files = await bbFetchPaginated<{ lines_added: number; lines_removed: number }>(
       `/repositories/${repoFullName}/pullrequests/${prId}/diffstat`,
       token,
     );
     let additions = 0;
     let deletions = 0;
-    for (const file of result.values) {
+    for (const file of files) {
       additions += file.lines_added;
       deletions += file.lines_removed;
     }

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -201,8 +201,8 @@ async function hydratePR(
     changesRequestedBy: changesRequestedBy.length > 0 ? changesRequestedBy : undefined,
     unresolvedCommentCount,
     unresolvedCommentAuthors: unresolvedCommentAuthors.length > 0 ? unresolvedCommentAuthors : undefined,
-    additions: diffStats.additions || undefined,
-    deletions: diffStats.deletions || undefined,
+    additions: diffStats?.additions,
+    deletions: diffStats?.deletions,
     description: pr.description || undefined,
     hasConflicts: false, // Would need separate merge check
     isAuthor: pr.author.nickname === username,
@@ -218,7 +218,7 @@ async function fetchDiffStats(
   token: string,
   repoFullName: string,
   prId: number,
-): Promise<{ additions: number; deletions: number }> {
+): Promise<{ additions: number; deletions: number } | undefined> {
   try {
     const files = await bbFetchPaginated<{ lines_added: number; lines_removed: number }>(
       `/repositories/${repoFullName}/pullrequests/${prId}/diffstat?pagelen=100`,
@@ -233,7 +233,7 @@ async function fetchDiffStats(
     }
     return { additions, deletions };
   } catch {
-    return { additions: 0, deletions: 0 };
+    return undefined;
   }
 }
 

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -289,6 +289,7 @@ async function hydratePR(
     updatedAt: pr.updated_at,
     ciStatus: ciResult.status,
     ciFailedChecks: ciResult.failedChecks.length > 0 ? ciResult.failedChecks : undefined,
+    ciDurationMs: ciResult.durationMs,
     reviewStatus,
     approvalCount,
     approvedBy: approvedBy.length > 0 ? approvedBy : undefined,
@@ -313,6 +314,7 @@ async function hydratePR(
 interface CIResult {
   status: CIStatus;
   failedChecks: string[];
+  durationMs?: number;
 }
 
 async function fetchCIStatus(token: string, repoFullName: string, headSha: string): Promise<CIResult> {
@@ -323,7 +325,7 @@ async function fetchCIStatus(token: string, repoFullName: string, headSha: strin
         `/repos/${repoFullName}/commits/${headSha}/status`,
         token,
       ),
-      ghFetch<{ total_count: number; check_runs: { name: string; status: string; conclusion: string | null }[] }>(
+      ghFetch<{ total_count: number; check_runs: { name: string; status: string; conclusion: string | null; started_at: string | null; completed_at: string | null }[] }>(
         `/repos/${repoFullName}/commits/${headSha}/check-runs`,
         token,
       ),
@@ -333,17 +335,20 @@ async function fetchCIStatus(token: string, repoFullName: string, headSha: strin
     if (checkRuns.total_count > 0) {
       const runs = checkRuns.check_runs;
 
+      // Compute total CI duration from earliest start to latest completion
+      const durationMs = computeCheckRunDuration(runs);
+
       const failedRuns = runs.filter(
         (r) => r.conclusion === 'failure' || r.conclusion === 'timed_out',
       );
       if (failedRuns.length > 0) {
-        return { status: 'failed', failedChecks: failedRuns.map((r) => r.name) };
+        return { status: 'failed', failedChecks: failedRuns.map((r) => r.name), durationMs };
       }
 
       const hasRunning = runs.some(
         (r) => r.status === 'in_progress' || r.status === 'queued',
       );
-      if (hasRunning) return { status: 'running', failedChecks: [] };
+      if (hasRunning) return { status: 'running', failedChecks: [], durationMs };
 
       const allDone = runs.every((r) => r.status === 'completed');
       if (allDone) {
@@ -351,12 +356,12 @@ async function fetchCIStatus(token: string, repoFullName: string, headSha: strin
           (r) => r.conclusion !== 'success' && r.conclusion !== 'neutral' && r.conclusion !== 'skipped',
         );
         if (nonSuccess.length > 0) {
-          return { status: 'failed', failedChecks: nonSuccess.map((r) => r.name) };
+          return { status: 'failed', failedChecks: nonSuccess.map((r) => r.name), durationMs };
         }
-        return { status: 'passed', failedChecks: [] };
+        return { status: 'passed', failedChecks: [], durationMs };
       }
 
-      return { status: 'pending', failedChecks: [] };
+      return { status: 'pending', failedChecks: [], durationMs };
     }
 
     // Fall back to legacy commit status API
@@ -369,6 +374,20 @@ async function fetchCIStatus(token: string, repoFullName: string, headSha: strin
   } catch {
     return { status: 'unknown', failedChecks: [] };
   }
+}
+
+function computeCheckRunDuration(runs: { started_at: string | null; completed_at: string | null }[]): number | undefined {
+  const starts: number[] = [];
+  const ends: number[] = [];
+  for (const r of runs) {
+    if (r.started_at) starts.push(new Date(r.started_at).getTime());
+    if (r.completed_at) ends.push(new Date(r.completed_at).getTime());
+  }
+  if (starts.length === 0) return undefined;
+  const earliest = Math.min(...starts);
+  // If still running, measure from earliest start to now
+  const latest = ends.length > 0 ? Math.max(...ends) : Date.now();
+  return latest - earliest;
 }
 
 /** Only count reviews on the current head commit — stale reviews on older commits don't count. */

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -296,8 +296,8 @@ async function hydratePR(
     changesRequestedBy: changesRequestedBy.length > 0 ? changesRequestedBy : undefined,
     unresolvedCommentCount: graphqlDetails.unresolvedCommentCount,
     unresolvedCommentAuthors: graphqlDetails.unresolvedCommentAuthors?.length ? graphqlDetails.unresolvedCommentAuthors : undefined,
-    additions: graphqlDetails.additions || undefined,
-    deletions: graphqlDetails.deletions || undefined,
+    additions: graphqlDetails.additions,
+    deletions: graphqlDetails.deletions,
     description: pr.body || undefined,
     hasConflicts: graphqlDetails.hasConflicts,
     isAuthor: pr.user.login === username,
@@ -385,8 +385,9 @@ function computeCheckRunDuration(runs: { started_at: string | null; completed_at
   }
   if (starts.length === 0) return undefined;
   const earliest = Math.min(...starts);
-  // If still running, measure from earliest start to now
-  const latest = ends.length > 0 ? Math.max(...ends) : Date.now();
+  const hasRunning = runs.some((r) => r.started_at && !r.completed_at);
+  // If any check is still running, measure to now; otherwise use latest completion
+  const latest = hasRunning ? Date.now() : (ends.length > 0 ? Math.max(...ends) : Date.now());
   return latest - earliest;
 }
 

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -95,6 +95,7 @@ interface GHPullRequest {
   id: number;
   number: number;
   title: string;
+  body: string | null;
   html_url: string;
   user: GHUser;
   draft: boolean;
@@ -294,6 +295,9 @@ async function hydratePR(
     changesRequestedBy: changesRequestedBy.length > 0 ? changesRequestedBy : undefined,
     unresolvedCommentCount: graphqlDetails.unresolvedCommentCount,
     unresolvedCommentAuthors: graphqlDetails.unresolvedCommentAuthors?.length ? graphqlDetails.unresolvedCommentAuthors : undefined,
+    additions: graphqlDetails.additions || undefined,
+    deletions: graphqlDetails.deletions || undefined,
+    description: pr.body || undefined,
     hasConflicts: graphqlDetails.hasConflicts,
     isAuthor: pr.user.login === username,
     isBot: pr.user.type === 'Bot',
@@ -445,6 +449,8 @@ interface GraphQLPRDetails {
   unresolvedCommentCount: number;
   unresolvedCommentAuthors?: string[];
   hasConflicts: boolean;
+  additions: number;
+  deletions: number;
 }
 
 interface GraphQLResponse<T> {
@@ -463,6 +469,8 @@ interface GraphQLPullRequestData {
   repository?: {
     pullRequest?: {
       mergeable?: string;
+      additions?: number;
+      deletions?: number;
       reviewThreads?: ReviewThreadConnection;
     };
   };
@@ -494,6 +502,8 @@ async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $prNumber) {
         mergeable
+        additions
+        deletions
         reviewThreads(first: 100, after: $after) {
           pageInfo {
             hasNextPage
@@ -512,6 +522,8 @@ async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber
     let unresolvedCommentCount = 0;
     const unresolvedAuthors = new Set<string>();
     let hasConflicts = false;
+    let additions = 0;
+    let deletions = 0;
     let after: string | null = null;
     let pageCount = 0;
 
@@ -524,7 +536,7 @@ async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber
       });
 
       const pr: GraphQLPullRequest | undefined = data?.repository?.pullRequest;
-      if (!pr) return { unresolvedCommentCount: 0, hasConflicts: false };
+      if (!pr) return { unresolvedCommentCount: 0, hasConflicts: false, additions: 0, deletions: 0 };
 
       const threads = pr.reviewThreads?.nodes ?? [];
       for (const t of threads) {
@@ -535,6 +547,8 @@ async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber
         }
       }
       hasConflicts = pr.mergeable === 'CONFLICTING';
+      additions = pr.additions ?? 0;
+      deletions = pr.deletions ?? 0;
 
       const pageInfo: ReviewThreadConnection['pageInfo'] = pr.reviewThreads?.pageInfo;
       if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
@@ -543,8 +557,8 @@ async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber
       pageCount += 1;
     }
 
-    return { unresolvedCommentCount, unresolvedCommentAuthors: [...unresolvedAuthors], hasConflicts };
+    return { unresolvedCommentCount, unresolvedCommentAuthors: [...unresolvedAuthors], hasConflicts, additions, deletions };
   } catch {
-    return { unresolvedCommentCount: 0, hasConflicts: false };
+    return { unresolvedCommentCount: 0, hasConflicts: false, additions: 0, deletions: 0 };
   }
 }

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -24,6 +24,7 @@ interface GLMergeRequest {
   id: number;
   iid: number;
   title: string;
+  description: string | null;
   web_url: string;
   author: GLUser;
   work_in_progress: boolean;
@@ -149,7 +150,7 @@ async function hydrateMR(
   mr: GLMergeRequest,
   username: string,
 ): Promise<PullRequest> {
-  const [discussions, approvals, deployment] = await Promise.all([
+  const [discussions, approvals, deployment, diffStats] = await Promise.all([
     glFetch<GLDiscussion[]>(
       `/projects/${encodedPath}/merge_requests/${mr.iid}/discussions`,
       token,
@@ -159,6 +160,7 @@ async function hydrateMR(
       token,
     ),
     fetchDeployment(token, encodedPath, mr.sha),
+    fetchDiffStats(token, encodedPath, mr.iid),
   ]);
 
   const unresolvedNotes = discussions.flatMap((d) =>
@@ -198,6 +200,9 @@ async function hydrateMR(
     approvalCount: approvals.approved_by.length,
     unresolvedCommentCount,
     unresolvedCommentAuthors: unresolvedCommentAuthors.length > 0 ? unresolvedCommentAuthors : undefined,
+    additions: diffStats.additions || undefined,
+    deletions: diffStats.deletions || undefined,
+    description: mr.description || undefined,
     hasConflicts: mr.has_conflicts,
     isAuthor: mr.author.username === username,
     isBot: false,
@@ -207,6 +212,30 @@ async function hydrateMR(
     headSha: mr.sha,
     deployment,
   };
+}
+
+async function fetchDiffStats(
+  token: string,
+  encodedPath: string,
+  mrIid: number,
+): Promise<{ additions: number; deletions: number }> {
+  try {
+    const changes = await glFetch<{ changes: { diff: string; new_path: string; old_path: string }[] }>(
+      `/projects/${encodedPath}/merge_requests/${mrIid}/changes?access_raw_diffs=false`,
+      token,
+    );
+    let additions = 0;
+    let deletions = 0;
+    for (const change of changes.changes ?? []) {
+      for (const line of change.diff.split('\n')) {
+        if (line.startsWith('+') && !line.startsWith('+++')) additions++;
+        else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+      }
+    }
+    return { additions, deletions };
+  } catch {
+    return { additions: 0, deletions: 0 };
+  }
 }
 
 async function fetchDeployment(

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -220,13 +220,16 @@ async function fetchDiffStats(
   mrIid: number,
 ): Promise<{ additions: number; deletions: number }> {
   try {
-    const changes = await glFetch<{ changes: { diff: string; new_path: string; old_path: string }[] }>(
+    const response = await glFetch<{ overflow?: boolean; changes: { diff: string }[] }>(
       `/projects/${encodedPath}/merge_requests/${mrIid}/changes?access_raw_diffs=false`,
       token,
     );
+    if (response.overflow) {
+      return { additions: 0, deletions: 0 };
+    }
     let additions = 0;
     let deletions = 0;
-    for (const change of changes.changes ?? []) {
+    for (const change of response.changes ?? []) {
       for (const line of change.diff.split('\n')) {
         if (line.startsWith('+') && !line.startsWith('+++')) additions++;
         else if (line.startsWith('-') && !line.startsWith('---')) deletions++;

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -196,14 +196,14 @@ async function hydrateMR(
     createdAt: mr.created_at,
     updatedAt: mr.updated_at,
     ciStatus,
-    ciDurationMs: mr.head_pipeline?.duration ? mr.head_pipeline.duration * 1000 : undefined,
+    ciDurationMs: mr.head_pipeline?.duration != null ? mr.head_pipeline.duration * 1000 : undefined,
     ciUrl: mr.head_pipeline?.web_url,
     reviewStatus,
     approvalCount: approvals.approved_by.length,
     unresolvedCommentCount,
     unresolvedCommentAuthors: unresolvedCommentAuthors.length > 0 ? unresolvedCommentAuthors : undefined,
-    additions: diffStats.additions || undefined,
-    deletions: diffStats.deletions || undefined,
+    additions: diffStats?.additions,
+    deletions: diffStats?.deletions,
     description: mr.description || undefined,
     hasConflicts: mr.has_conflicts,
     isAuthor: mr.author.username === username,
@@ -220,15 +220,13 @@ async function fetchDiffStats(
   token: string,
   encodedPath: string,
   mrIid: number,
-): Promise<{ additions: number; deletions: number }> {
+): Promise<{ additions: number; deletions: number } | undefined> {
   try {
     const response = await glFetch<{ overflow?: boolean; changes: { diff: string }[] }>(
       `/projects/${encodedPath}/merge_requests/${mrIid}/changes?access_raw_diffs=false`,
       token,
     );
-    if (response.overflow) {
-      return { additions: 0, deletions: 0 };
-    }
+    if (response.overflow) return undefined;
     let additions = 0;
     let deletions = 0;
     for (const change of response.changes ?? []) {
@@ -239,7 +237,7 @@ async function fetchDiffStats(
     }
     return { additions, deletions };
   } catch {
-    return { additions: 0, deletions: 0 };
+    return undefined;
   }
 }
 

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -233,8 +233,8 @@ async function fetchDiffStats(
     let deletions = 0;
     for (const change of response.changes ?? []) {
       for (const line of change.diff.split('\n')) {
-        if (line.startsWith('+') && !line.startsWith('+++')) additions++;
-        else if (line.startsWith('-') && !line.startsWith('---')) deletions++;
+        if (line.startsWith('+') && !line.startsWith('+++ ')) additions++;
+        else if (line.startsWith('-') && !line.startsWith('--- ')) deletions++;
       }
     }
     return { additions, deletions };

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -38,6 +38,7 @@ interface GLMergeRequest {
   head_pipeline?: {
     status: string;
     web_url: string;
+    duration: number | null;
   } | null;
 }
 
@@ -195,6 +196,7 @@ async function hydrateMR(
     createdAt: mr.created_at,
     updatedAt: mr.updated_at,
     ciStatus,
+    ciDurationMs: mr.head_pipeline?.duration ? mr.head_pipeline.duration * 1000 : undefined,
     ciUrl: mr.head_pipeline?.web_url,
     reviewStatus,
     approvalCount: approvals.approved_by.length,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -29,6 +29,7 @@ export interface PullRequest {
   updatedAt: string;
   ciStatus: CIStatus;
   ciFailedChecks?: string[];
+  ciDurationMs?: number;
   ciUrl?: string;
   reviewStatus: ReviewStatus;
   approvalCount: number;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -36,6 +36,9 @@ export interface PullRequest {
   changesRequestedBy?: string[];
   unresolvedCommentCount: number;
   unresolvedCommentAuthors?: string[];
+  additions?: number;
+  deletions?: number;
+  description?: string;
   hasConflicts: boolean;
   isAuthor: boolean;
   isBot: boolean;


### PR DESCRIPTION
## Summary

- Show `+N -N` diff stats on each PR row (GitHub via GraphQL, GitLab via changes endpoint, Bitbucket via diffstat API)
- Add collapsible description preview below PR items for quick context without leaving the popup

## Test plan

- [ ] Verify diff stats badge shows green/red `+N -N` for GitHub PRs
- [ ] Verify diff stats for GitLab MRs
- [ ] Verify diff stats for Bitbucket PRs
- [ ] Verify "Show description" toggle appears for PRs with a description
- [ ] Verify description is truncated at 500 chars with scrollable container
- [ ] Verify PRs without a description don't show the toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggleable PR descriptions (show/hide, truncated to 500 chars with max-height scrolling).
  * Visible code change stats per PR (+additions / -deletions), hidden when unavailable.

* **UI / Badges**
  * Approval / unresolved / reviewing badges now show only icons + counts.
  * CI badge shows icon-only, can display concise duration next to the icon, and includes duration in tooltips for failed/other statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->