### PR TITLE
Add community section and GitHub star nudge

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,6 +1,6 @@
 import type { PullRequest, CIStatus, Message } from '@/shared/types';
 import { CI_STATUS_LABELS } from '@/shared/constants';
-import { getSettings, getAccounts, getWatchedRepos, getCachedPRs, saveCachedPRs } from '@/shared/storage';
+import { getSettings, getAccounts, getWatchedRepos, getCachedPRs, saveCachedPRs, setInstallDate } from '@/shared/storage';
 import * as github from '@/shared/api/github';
 import * as gitlab from '@/shared/api/gitlab';
 import * as bitbucket from '@/shared/api/bitbucket';
@@ -34,6 +34,7 @@ async function saveLastCommentCounts(counts: Record<string, number>): Promise<vo
 // === Lifecycle ===
 
 chrome.runtime.onInstalled.addListener(() => {
+  setInstallDate();
   setupPolling();
 });
 

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { AppView, DashboardTab, PullRequest, UrgencyCategory } from '@/shared/types';
-import { getWatchedRepos, getCachedPRs, getSettings } from '@/shared/storage';
-import { CHROME_WEB_STORE_URL } from '@/shared/constants';
+import { getWatchedRepos, getCachedPRs, getSettings, getInstallDate, isStarPromptDismissed, dismissStarPrompt } from '@/shared/storage';
+import { CHROME_WEB_STORE_URL, GITHUB_REPO_URL } from '@/shared/constants';
 import { matchesUrgencyFilter, computeUrgencyCounts } from '../utils/urgency';
 import PRItem from '../components/PRItem';
 import TriageSummary from '../components/TriageSummary';
@@ -28,6 +28,7 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
   const [stalePRDays, setStalePRDays] = useState(45);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const [urgencyFilter, setUrgencyFilter] = useState<UrgencyCategory | null>(null);
+  const [showStarBanner, setShowStarBanner] = useState(false);
 
   const loadPinnedRepos = useCallback(async () => {
     const watchedRepos = await getWatchedRepos();
@@ -106,6 +107,17 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
     chrome.storage.local.onChanged.addListener(onStorageChange);
     return () => chrome.storage.local.onChanged.removeListener(onStorageChange);
   }, [loadPinnedRepos]);
+
+  // Check if star banner should show (7+ days since install, not dismissed)
+  useEffect(() => {
+    async function checkStarBanner() {
+      const [installDate, dismissed] = await Promise.all([getInstallDate(), isStarPromptDismissed()]);
+      if (dismissed || !installDate) return;
+      const daysSinceInstall = (Date.now() - installDate) / 86400000;
+      if (daysSinceInstall >= 7) setShowStarBanner(true);
+    }
+    checkStarBanner();
+  }, []);
 
   // Reset urgency filter on tab change
   useEffect(() => { setUrgencyFilter(null); }, [tab]);
@@ -225,6 +237,27 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
           </span>
         ) : null}
       </div>
+
+      {/* Star banner */}
+      {showStarBanner && (
+        <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-radar-900/50 bg-radar-950/30">
+          <a
+            href={GITHUB_REPO_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[11px] text-gray-400 hover:text-radar-400 transition-colors"
+          >
+            &#9733; Enjoying PR Radar? <span className="text-radar-400">Star us on GitHub</span> to help others discover it
+          </a>
+          <button
+            onClick={() => { setShowStarBanner(false); dismissStarPrompt(); }}
+            className="text-gray-600 hover:text-gray-400 text-xs leading-none flex-shrink-0"
+            title="Dismiss"
+          >
+            &#10005;
+          </button>
+        </div>
+      )}
 
       {/* PR list */}
       <div className="flex-1 overflow-y-auto">

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import type { AppView, Platform } from '@/shared/types';
 import { PLATFORM_LABELS, SOUND_OPTIONS } from '@/shared/constants';
 import { getSettings, saveSettings, getAccounts, removeAccount, type Settings as SettingsType } from '@/shared/storage';
-import { CHROME_WEB_STORE_URL } from '@/shared/constants';
+import { CHROME_WEB_STORE_URL, GITHUB_REPO_URL, GITHUB_ISSUES_URL } from '@/shared/constants';
 
 interface SettingsProps {
   onNavigate: (view: AppView) => void;
@@ -180,24 +180,49 @@ export default function Settings({ onNavigate }: SettingsProps) {
           ))}
       </Section>
 
-      {/* Share & About */}
-      <div className="mb-5 rounded-lg bg-radar-950/50 border border-radar-900/50 px-4 py-3">
-        <div className="flex items-center justify-between">
-          <div>
-            <div className="text-[13px] text-gray-200 font-medium">Share with your team</div>
-            <div className="text-[11px] text-gray-500 mt-0.5">Works best when your whole team uses it</div>
-          </div>
-          <CopyLinkButton url={CHROME_WEB_STORE_URL} />
-        </div>
-      </div>
-      <div className="text-center pb-2">
+      {/* Community */}
+      <div className="mb-5 space-y-2">
         <a
-          href="https://github.com/deployhq/pr-radar"
+          href={CHROME_WEB_STORE_URL}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-[11px] text-gray-500 hover:text-radar-400 transition-colors"
+          className="block rounded-lg bg-radar-950/50 border border-radar-900/50 px-4 py-3 hover:border-radar-700/50 transition-colors"
         >
-          Open source on GitHub
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-[13px] text-gray-200 font-medium">&#128229; Share with your team</div>
+              <div className="text-[11px] text-gray-500 mt-0.5">Works best when your whole team uses it</div>
+            </div>
+            <span className="text-gray-600 text-xs">&#8594;</span>
+          </div>
+        </a>
+        <a
+          href={GITHUB_REPO_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block rounded-lg bg-radar-950/50 border border-radar-900/50 px-4 py-3 hover:border-radar-700/50 transition-colors"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-[13px] text-gray-200 font-medium">&#9733; Star us on GitHub</div>
+              <div className="text-[11px] text-gray-500 mt-0.5">Help others discover PR Radar</div>
+            </div>
+            <span className="text-gray-600 text-xs">&#8594;</span>
+          </div>
+        </a>
+        <a
+          href={GITHUB_ISSUES_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block rounded-lg bg-radar-950/50 border border-radar-900/50 px-4 py-3 hover:border-radar-700/50 transition-colors"
+        >
+          <div className="flex items-center justify-between">
+            <div>
+              <div className="text-[13px] text-gray-200 font-medium">&#128172; Feedback &amp; Ideas</div>
+              <div className="text-[11px] text-gray-500 mt-0.5">Report bugs or suggest features</div>
+            </div>
+            <span className="text-gray-600 text-xs">&#8594;</span>
+          </div>
         </a>
       </div>
     </div>
@@ -235,24 +260,6 @@ function SettingRow({
   );
 }
 
-function CopyLinkButton({ url }: { url: string }) {
-  const [copied, setCopied] = useState(false);
-
-  async function handleCopy() {
-    await navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="text-[11px] px-3 py-1 rounded-md border border-gray-600 text-gray-400 hover:border-gray-500 hover:text-gray-300 transition-colors"
-    >
-      {copied ? 'Copied!' : 'Copy link'}
-    </button>
-  );
-}
 
 function Toggle({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
   return (

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -46,3 +46,6 @@ export type SoundId = typeof SOUND_OPTIONS[number]['id'];
 
 export const CHROME_WEB_STORE_URL =
   'https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh';
+
+export const GITHUB_REPO_URL = 'https://github.com/deployhq/pr-radar';
+export const GITHUB_ISSUES_URL = 'https://github.com/deployhq/pr-radar/issues';

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -102,14 +102,21 @@ export async function saveCachedPRs(prs: PullRequest[]): Promise<void> {
   });
 }
 
-export async function clearAll(): Promise<void> {
-  await chrome.storage.local.remove([ACCOUNTS_KEY, SETTINGS_KEY, REPOS_KEY, PR_CACHE_KEY]);
-}
-
 // === Install date & star prompt ===
 
 const INSTALL_DATE_KEY = 'pr_radar_install_date';
 const STAR_PROMPT_DISMISSED_KEY = 'pr_radar_star_dismissed';
+
+export async function clearAll(): Promise<void> {
+  await chrome.storage.local.remove([
+    ACCOUNTS_KEY,
+    SETTINGS_KEY,
+    REPOS_KEY,
+    PR_CACHE_KEY,
+    INSTALL_DATE_KEY,
+    STAR_PROMPT_DISMISSED_KEY,
+  ]);
+}
 
 export async function getInstallDate(): Promise<number | null> {
   const result = await chrome.storage.local.get(INSTALL_DATE_KEY);

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -105,3 +105,29 @@ export async function saveCachedPRs(prs: PullRequest[]): Promise<void> {
 export async function clearAll(): Promise<void> {
   await chrome.storage.local.remove([ACCOUNTS_KEY, SETTINGS_KEY, REPOS_KEY, PR_CACHE_KEY]);
 }
+
+// === Install date & star prompt ===
+
+const INSTALL_DATE_KEY = 'pr_radar_install_date';
+const STAR_PROMPT_DISMISSED_KEY = 'pr_radar_star_dismissed';
+
+export async function getInstallDate(): Promise<number | null> {
+  const result = await chrome.storage.local.get(INSTALL_DATE_KEY);
+  return result[INSTALL_DATE_KEY] ?? null;
+}
+
+export async function setInstallDate(): Promise<void> {
+  const existing = await getInstallDate();
+  if (!existing) {
+    await chrome.storage.local.set({ [INSTALL_DATE_KEY]: Date.now() });
+  }
+}
+
+export async function isStarPromptDismissed(): Promise<boolean> {
+  const result = await chrome.storage.local.get(STAR_PROMPT_DISMISSED_KEY);
+  return result[STAR_PROMPT_DISMISSED_KEY] === true;
+}
+
+export async function dismissStarPrompt(): Promise<void> {
+  await chrome.storage.local.set({ [STAR_PROMPT_DISMISSED_KEY]: true });
+}


### PR DESCRIPTION
## Summary
- **Settings community section**: Unified group of three cards (Share with your team, Star us on GitHub, Feedback & Ideas) with consistent styling and external links
- **Dashboard star banner**: Dismissible nudge that appears after 7 days of usage, encouraging users to star the repo on GitHub — persists dismissal across sessions
- **Storage helpers**: `installDate` recorded on first install, `starPromptDismissed` flag for banner state

## Test plan
- [ ] Open Settings → verify three community cards appear at the bottom with consistent styling
- [ ] Click each card → verify they open the correct URLs (Chrome Web Store, GitHub repo, GitHub Issues)
- [ ] Set install date to 8+ days ago via console: `chrome.storage.local.set({ pr_radar_install_date: Date.now() - 8 * 86400000 })`
- [ ] Reopen popup → verify star banner appears on Dashboard above the PR list
- [ ] Click ✕ on banner → verify it disappears and doesn't return after reopening popup
- [ ] Reset with `chrome.storage.local.remove('pr_radar_star_dismissed')` → verify banner reappears
- [ ] Fresh install (no `pr_radar_install_date`) → verify banner does NOT appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Star us on GitHub" banner in the Dashboard that appears 7 days after install and can be dismissed.
  * Reworked Settings → Community: direct external links to the Web Store, project repo, and feedback/issues.

* **Persistence**
  * Installation date is now recorded and the banner dismissal is persisted so the prompt stays dismissed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->