### PR TITLE
Add opt-in DeployHQ integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ src/
       github.ts                  # GitHub REST + GraphQL API (PRs, CI, reviews, threads, deployments, orgs, merge)
       gitlab.ts                  # GitLab REST API (MRs, CI pipelines, discussions, approvals, deployments, merge)
       bitbucket.ts               # Bitbucket REST API (PRs, pipelines, comments, participants, merge, workspaces)
+      deployhq.ts                # DeployHQ REST API (projects, servers, deployments — opt-in integration)
 public/
   offscreen.html                 # Offscreen document for audio playback (references offscreen.js)
   offscreen.js                   # Audio player (separate file required by MV3 CSP - no inline scripts)
@@ -106,6 +107,17 @@ Uses PATs (Personal Access Tokens) — no backend needed. Setup page links pre-f
 - **CI status**: From pipelines API filtered by source branch
 - **Review tracking**: `hasReviewed` derived from participant state
 - **Limitations**: No draft PR detection (Bitbucket doesn't support drafts), no conflict detection via API
+
+### DeployHQ (opt-in)
+
+The extension works fully without DeployHQ. This integration is entirely opt-in — configured in Settings > Accounts > DeployHQ.
+
+- **Auth**: HTTP Basic auth (`email:apiKey` base64-encoded) against `https://{slug}.deployhq.com`
+- **REST endpoints**: `/account` (test connection), `/projects` + `/projects/{permalink}` (list projects with repo URLs), `/projects/{permalink}/servers` + `/server_groups` (deployment targets), `/projects/{permalink}/deployments` (create deployment)
+- **Repo matching**: During polling, fetches DeployHQ projects and matches their repository URLs against PR `repoFullName`. Mapping cached in `chrome.storage.local`
+- **Deployment status**: Checks each server's `last_revision` against PR `headSha` to show persistent deployment badges
+- **Deploy from dashboard**: Deploy button on subtitle row for matched PRs; inline server/group selector with confirm/cancel flow
+- **Deployment badge**: Shown in badge row as clickable `🚀 ServerName` linking to the DeployHQ dashboard
 
 ## Key Design Decisions
 
@@ -151,6 +163,7 @@ Uses PATs (Personal Access Tokens) — no backend needed. Setup page links pre-f
 - **Compact badges** — Icon-only CI status, icon+count for approvals (👤), unresolved comments (💬), pending reviewers (⏳), changes requested (↻); full details in tooltips
 - **Keyboard shortcuts** — `j`/`k` or arrows navigate PR list with visual focus ring, `o`/`Enter` opens PR, `1`/`2`/`3` switch tabs, `/` focuses search, `r` refreshes, `Escape` clears search/filter/focus, `?` toggles cheat sheet overlay; all shortcuts disabled when search input is focused (except Escape); "Press ? for shortcuts" hint in footer
 - **Accessibility** — ARIA labels/roles on all interactive elements, `role="tab"`/`role="switch"`/`role="checkbox"` semantics, `aria-live` regions for status updates, `aria-expanded` on collapsible sections, decorative icons hidden from screen readers, form inputs labeled
+- **DeployHQ integration (opt-in)** — Connect your DeployHQ account in Settings to deploy directly from the dashboard; select server/group with confirm step; persistent deployment badge (`🚀 ServerName`) links to DeployHQ dashboard; works for deployments made inside or outside PR Radar; the extension works fully without enabling this
 - **Branding** — "Made with love by DeployHQ" footer with UTM tracking
 
 ## Publishing

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Free, by [DeployHQ](https://www.deployhq.com/?utm_source=pr-radar&utm_medium=git
 - **Toolbar badge** — Icon shows pass/fail/running count at a glance
 - **Instant load** — Cached data shown immediately, refreshes in background
 - **Keyboard shortcuts** — Navigate PRs with `j`/`k`, open with `o`, switch tabs with `1`/`2`/`3`, search with `/`, press `?` for the full list
+- **DeployHQ integration** — Optionally connect your [DeployHQ](https://www.deployhq.com/?utm_source=pr-radar&utm_medium=github&utm_campaign=readme) account to deploy directly from the dashboard with server selection
 - **Privacy-first** — Your token stays on your device. No backend, no tracking
 
 ## Install
@@ -119,6 +120,15 @@ The popup shows cached data instantly and refreshes in the background — no loa
 | Gray `?` | Polling error |
 
 Stale PRs are excluded from the badge count.
+
+## DeployHQ Integration (optional)
+
+PR Radar works perfectly on its own — the DeployHQ integration is entirely opt-in. If you use [DeployHQ](https://www.deployhq.com/?utm_source=pr-radar&utm_medium=github&utm_campaign=readme) for deployments, you can connect your account to:
+
+- **Deploy from the dashboard** — Click Deploy on any PR whose repo matches a DeployHQ project, pick a server or server group, and confirm
+- **See deployment status** — A persistent badge shows which server a PR's revision is deployed to, linking directly to the DeployHQ dashboard
+
+To set up: go to **Settings > Accounts > DeployHQ > Connect**, enter your account slug, email, and API key (found in DeployHQ > Settings > Security), and click Connect.
 
 ## Settings
 

--- a/manifest.json
+++ b/manifest.json
@@ -24,7 +24,8 @@
     "https://api.github.com/*",
     "https://gitlab.com/*",
     "https://api.bitbucket.org/*",
-    "https://id.atlassian.com/*"
+    "https://id.atlassian.com/*",
+    "https://*.deployhq.com/*"
   ],
   "{{chrome}}.background": {
     "service_worker": "src/background/service-worker.ts",

--- a/mockups/deployhq-integration.html
+++ b/mockups/deployhq-integration.html
@@ -1,0 +1,831 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>PR Radar - DeployHQ Integration Mockups</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { background: #0f0f0f; color: #e5e7eb; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; padding: 30px; }
+
+  h1 { text-align: center; font-size: 18px; color: #9ca3af; margin-bottom: 8px; font-weight: 400; }
+  .subtitle { text-align: center; font-size: 13px; color: #6b7280; margin-bottom: 40px; }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+    gap: 32px;
+    max-width: 1200px;
+    margin: 0 auto 50px;
+  }
+
+  .single { max-width: 420px; margin: 0 auto 50px; }
+
+  .section-title {
+    font-size: 14px;
+    color: #7c6cc8;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    margin-bottom: 20px;
+    text-align: center;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #2a2a3e;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .option {
+    background: #1a1a2e;
+    border-radius: 12px;
+    overflow: hidden;
+    border: 1px solid #2a2a3e;
+  }
+
+  .option-header {
+    padding: 12px 16px;
+    background: #12121e;
+    border-bottom: 1px solid #2a2a3e;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .option-label {
+    font-size: 11px;
+    font-weight: 700;
+    color: #7c6cc8;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+  }
+
+  .option-desc {
+    font-size: 11px;
+    color: #6b7280;
+  }
+
+  .option-body { padding: 0; }
+
+  /* Settings section styles */
+  .settings-section {
+    padding: 16px;
+  }
+
+  .settings-title {
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: #9ca3af;
+    font-weight: 600;
+    margin-bottom: 8px;
+  }
+
+  .setting-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 10px 0;
+    border-bottom: 1px solid #1f1f35;
+  }
+  .setting-row:last-child { border-bottom: none; }
+
+  .setting-label {
+    font-size: 13px;
+    color: #e5e7eb;
+  }
+
+  .setting-desc {
+    font-size: 11px;
+    color: #6b7280;
+    margin-top: 2px;
+  }
+
+  .input-field {
+    background: #12121e;
+    border: 1px solid #2a2a3e;
+    border-radius: 6px;
+    padding: 6px 10px;
+    font-size: 12px;
+    color: #e5e7eb;
+    width: 180px;
+    outline: none;
+  }
+  .input-field::placeholder { color: #4b5563; }
+  .input-field:focus { border-color: #5740cf; }
+
+  .input-field.full-width { width: 100%; margin-top: 6px; }
+
+  .input-group { margin-bottom: 10px; }
+  .input-group label {
+    display: block;
+    font-size: 12px;
+    color: #9ca3af;
+    margin-bottom: 4px;
+  }
+
+  .btn {
+    font-size: 11px;
+    padding: 6px 14px;
+    border-radius: 6px;
+    border: 1px solid;
+    cursor: pointer;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    transition: all 0.15s;
+  }
+
+  .btn-primary {
+    background: #5740cf;
+    color: white;
+    border-color: #6b54d9;
+  }
+  .btn-primary:hover { background: #6b54d9; }
+
+  .btn-ghost {
+    background: transparent;
+    color: #9ca3af;
+    border-color: #2a2a3e;
+  }
+  .btn-ghost:hover { color: #e5e7eb; border-color: #4b5563; }
+
+  .btn-danger {
+    background: transparent;
+    color: #9ca3af;
+    border: none;
+    padding: 4px 0;
+    font-size: 11px;
+    cursor: pointer;
+  }
+  .btn-danger:hover { color: #f87171; }
+
+  .connected-badge {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 12px;
+    color: #34d399;
+  }
+
+  .helper-text {
+    font-size: 11px;
+    color: #6b7280;
+    margin-top: 8px;
+  }
+  .helper-text a { color: #7c6cc8; text-decoration: none; }
+  .helper-text a:hover { text-decoration: underline; }
+
+  .error-text {
+    font-size: 11px;
+    color: #f87171;
+    margin-top: 6px;
+  }
+
+  .spinner {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border: 2px solid rgba(255,255,255,0.3);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: spin 0.6s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* PR item styles */
+  .pr-item {
+    padding: 12px 16px;
+    border-bottom: 1px solid #1f1f35;
+    cursor: default;
+  }
+  .pr-item:last-child { border-bottom: none; }
+
+  .pr-row { display: flex; align-items: flex-start; gap: 10px; }
+
+  .gh-icon {
+    flex-shrink: 0;
+    width: 18px;
+    height: 18px;
+    margin-top: 2px;
+    fill: #9ca3af;
+  }
+
+  .pr-content { flex: 1; min-width: 0; }
+
+  .pr-title-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .pr-title {
+    font-size: 13px;
+    color: #e5e7eb;
+    font-weight: 500;
+    line-height: 1.3;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .pr-sub {
+    font-size: 11px;
+    color: #6b7280;
+    margin-top: 3px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .tag {
+    font-size: 9px;
+    padding: 1px 6px;
+    border-radius: 4px;
+    font-weight: 500;
+  }
+  .tag-author { background: rgba(87, 64, 207, 0.15); color: #a78bfa; }
+  .tag-review { background: rgba(245, 158, 11, 0.15); color: #fbbf24; }
+
+  .badge-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    margin-left: 28px;
+    flex-wrap: wrap;
+  }
+
+  .badge {
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 9999px;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+  }
+  .badge-green { background: rgba(16, 185, 129, 0.15); color: #34d399; }
+  .badge-amber { background: rgba(245, 158, 11, 0.1); color: #fbbf24; }
+  .badge-gray { background: rgba(107, 114, 128, 0.15); color: #9ca3af; }
+  .badge-blue { background: rgba(59, 130, 246, 0.15); color: #60a5fa; }
+
+  .time-ago {
+    font-size: 10px;
+    color: #4b5563;
+    margin-left: auto;
+  }
+
+  /* Action buttons in PR row */
+  .action-btn {
+    flex-shrink: 0;
+    font-size: 10px;
+    line-height: 1;
+    padding: 3px 8px;
+    border-radius: 6px;
+    font-weight: 600;
+    border: 1px solid;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+
+  .merge-btn {
+    background: #238636;
+    color: white;
+    border-color: #2ea043;
+  }
+
+  .deploy-btn {
+    background: #5740cf;
+    color: white;
+    border-color: #6b54d9;
+  }
+  .deploy-btn:hover { background: #6b54d9; }
+
+  .deploy-btn-disabled {
+    background: #21262d;
+    color: #484f58;
+    border-color: #30363d;
+    cursor: not-allowed;
+  }
+
+  .confirm-btn {
+    background: #5740cf;
+    color: white;
+    border-color: #6b54d9;
+  }
+
+  .cancel-btn {
+    background: #21262d;
+    color: #c9d1d9;
+    border-color: #30363d;
+  }
+
+  .deploying-btn {
+    background: #21262d;
+    color: #a78bfa;
+    border-color: #30363d;
+  }
+
+  .deployed-btn {
+    background: #5740cf;
+    color: white;
+    border-color: #5740cf;
+  }
+
+  .server-select {
+    background: #12121e;
+    border: 1px solid #2a2a3e;
+    border-radius: 6px;
+    padding: 2px 6px;
+    font-size: 10px;
+    color: #e5e7eb;
+    max-width: 120px;
+    outline: none;
+  }
+
+  .action-group {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .error-inline {
+    font-size: 10px;
+    color: #f87171;
+    max-width: 100px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .divider {
+    height: 40px;
+    border: none;
+  }
+
+  .annotation {
+    font-size: 11px;
+    color: #6b7280;
+    padding: 8px 16px;
+    background: rgba(87, 64, 207, 0.05);
+    border-top: 1px solid #2a2a3e;
+    font-style: italic;
+  }
+
+  .no-deploy-note {
+    font-size: 10px;
+    color: #4b5563;
+    padding: 6px 16px;
+    border-top: 1px solid #1f1f35;
+    font-style: italic;
+  }
+</style>
+</head>
+<body>
+
+<h1>PR Radar &mdash; DeployHQ Integration</h1>
+<p class="subtitle">Mockups for Settings configuration and Dashboard deploy actions</p>
+
+<!-- ============================================ -->
+<!-- SETTINGS SCREENS -->
+<!-- ============================================ -->
+
+<div class="section-title" style="margin-bottom: 24px;">Settings &mdash; DeployHQ Section</div>
+
+<div class="grid">
+
+  <!-- Not connected state -->
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">Not Connected</span>
+      <span class="option-desc">&mdash; Initial state, user enters credentials</span>
+    </div>
+    <div class="settings-section">
+      <div class="settings-title">DeployHQ</div>
+
+      <div class="input-group">
+        <label>Account</label>
+        <div style="display: flex; align-items: center; gap: 4px;">
+          <input type="text" class="input-field" style="width: 120px;" placeholder="my-company">
+          <span style="font-size: 12px; color: #6b7280;">.deployhq.com</span>
+        </div>
+      </div>
+
+      <div class="input-group">
+        <label>Email</label>
+        <input type="email" class="input-field full-width" placeholder="you@company.com">
+      </div>
+
+      <div class="input-group">
+        <label>API key</label>
+        <input type="password" class="input-field full-width" placeholder="&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;&#8226;">
+      </div>
+
+      <p class="helper-text">Find your API key in <a href="#">Settings &rarr; Security</a> in DeployHQ</p>
+
+      <div style="margin-top: 12px;">
+        <button class="btn btn-primary">Test Connection</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Testing connection -->
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">Testing</span>
+      <span class="option-desc">&mdash; Validating credentials</span>
+    </div>
+    <div class="settings-section">
+      <div class="settings-title">DeployHQ</div>
+
+      <div class="input-group">
+        <label>Account</label>
+        <div style="display: flex; align-items: center; gap: 4px;">
+          <input type="text" class="input-field" style="width: 120px; opacity: 0.5;" value="acme-corp" disabled>
+          <span style="font-size: 12px; color: #6b7280;">.deployhq.com</span>
+        </div>
+      </div>
+
+      <div class="input-group">
+        <label>Email</label>
+        <input type="email" class="input-field full-width" style="opacity: 0.5;" value="dev@acme.com" disabled>
+      </div>
+
+      <div class="input-group">
+        <label>API key</label>
+        <input type="password" class="input-field full-width" style="opacity: 0.5;" value="xxxxxxxxxxxx" disabled>
+      </div>
+
+      <div style="margin-top: 12px;">
+        <button class="btn btn-primary" style="opacity: 0.7; cursor: wait;">
+          <span class="spinner"></span> Testing...
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Connected state -->
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">Connected</span>
+      <span class="option-desc">&mdash; Credentials validated successfully</span>
+    </div>
+    <div class="settings-section">
+      <div class="settings-title">DeployHQ</div>
+
+      <div class="setting-row">
+        <div>
+          <div class="setting-label">
+            <span class="connected-badge">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+              Connected to Acme Corp
+            </span>
+          </div>
+          <div class="setting-desc">acme-corp.deployhq.com</div>
+        </div>
+        <button class="btn-danger">Disconnect</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Error state -->
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">Error</span>
+      <span class="option-desc">&mdash; Invalid credentials</span>
+    </div>
+    <div class="settings-section">
+      <div class="settings-title">DeployHQ</div>
+
+      <div class="input-group">
+        <label>Account</label>
+        <div style="display: flex; align-items: center; gap: 4px;">
+          <input type="text" class="input-field" style="width: 120px; border-color: #f87171;" value="wrong-slug">
+          <span style="font-size: 12px; color: #6b7280;">.deployhq.com</span>
+        </div>
+      </div>
+
+      <div class="input-group">
+        <label>Email</label>
+        <input type="email" class="input-field full-width" value="wrong@email.com">
+      </div>
+
+      <div class="input-group">
+        <label>API key</label>
+        <input type="password" class="input-field full-width" value="bad-key">
+      </div>
+
+      <p class="error-text">Authentication failed. Check your account name, email and API key.</p>
+
+      <div style="margin-top: 12px;">
+        <button class="btn btn-primary">Retry</button>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<hr class="divider">
+
+<!-- ============================================ -->
+<!-- DASHBOARD - DEPLOY BUTTON STATES -->
+<!-- ============================================ -->
+
+<div class="section-title" style="margin-bottom: 24px;">Dashboard &mdash; Deploy Button States</div>
+
+<div class="single">
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">PR with DeployHQ project</span>
+      <span class="option-desc">&mdash; All deploy states</span>
+    </div>
+    <div class="option-body">
+
+      <!-- State 1: Idle - both Merge and Deploy visible -->
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Add webhook retry with exponential backoff</span>
+              <button class="action-btn merge-btn">Merge</button>
+              <button class="action-btn deploy-btn">Deploy</button>
+            </div>
+            <div class="pr-sub">
+              <span>deployhq/deployhq #1842</span>
+              <span class="tag tag-author">Author</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-green">&#x1F464; 2</span>
+          <span class="badge badge-gray">+45 -12</span>
+          <span class="time-ago">2h ago</span>
+        </div>
+        <div class="annotation">&#x2191; Idle &mdash; Both Merge and Deploy buttons visible. Deploy uses DeployHQ purple.</div>
+      </div>
+
+      <!-- State 2: Loading servers -->
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Fix rate limiter for concurrent requests</span>
+              <button class="action-btn merge-btn">Merge</button>
+              <span class="action-btn deploying-btn"><span class="spinner" style="width: 10px; height: 10px; border-width: 1.5px;"></span></span>
+            </div>
+            <div class="pr-sub">
+              <span>deployhq/deployhq #1843</span>
+              <span class="tag tag-author">Author</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-gray">+8 -3</span>
+          <span class="time-ago">45m ago</span>
+        </div>
+        <div class="annotation">&#x2191; Loading &mdash; Fetching available servers from DeployHQ</div>
+      </div>
+
+      <!-- State 3: Server selection dropdown -->
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Update email templates for billing</span>
+              <span class="action-group">
+                <select class="server-select">
+                  <option>Production</option>
+                  <option selected>Staging</option>
+                  <option>Development</option>
+                </select>
+                <button class="action-btn confirm-btn">Deploy</button>
+                <button class="action-btn cancel-btn">Cancel</button>
+              </span>
+            </div>
+            <div class="pr-sub">
+              <span>deployhq/deployhq #1840</span>
+              <span class="tag tag-author">Author</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-green">&#x1F464; 1</span>
+          <span class="badge badge-amber">&#x1F4AC; 2</span>
+          <span class="badge badge-gray">+120 -34</span>
+          <span class="time-ago">1h ago</span>
+        </div>
+        <div class="annotation">&#x2191; Selecting &mdash; Server dropdown with confirm/cancel. Merge button hidden during selection.</div>
+      </div>
+
+      <!-- State 4: Deploying -->
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Migrate user sessions to Redis</span>
+              <button class="action-btn merge-btn">Merge</button>
+              <span class="action-btn deploying-btn"><span class="spinner" style="width: 10px; height: 10px; border-width: 1.5px;"></span> Deploying...</span>
+            </div>
+            <div class="pr-sub">
+              <span>deployhq/deployhq #1838</span>
+              <span class="tag tag-author">Author</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-green">&#x1F464; 3</span>
+          <span class="badge badge-gray">+210 -89</span>
+          <span class="time-ago">3h ago</span>
+        </div>
+        <div class="annotation">&#x2191; Deploying &mdash; Spinner with "Deploying..." text</div>
+      </div>
+
+      <!-- State 5: Deployed - status in badge row, Deploy button stays in title row -->
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Add CORS headers for API v3</span>
+              <button class="action-btn merge-btn">Merge</button>
+              <button class="action-btn deploy-btn">Deploy</button>
+            </div>
+            <div class="pr-sub">
+              <span>deployhq/deployhq #1835</span>
+              <span class="tag tag-author">Author</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-green">&#x1F464; 2</span>
+          <a href="#" title="Deployed to Staging &mdash; View in DeployHQ" style="text-decoration: none;">
+            <span class="badge" style="background: rgba(87, 64, 207, 0.15); color: #a78bfa; cursor: pointer;">&#x1F680; Staging</span>
+          </a>
+          <span class="badge badge-gray">+15 -4</span>
+          <span class="time-ago">5h ago</span>
+        </div>
+        <div class="annotation">&#x2191; Deployed &mdash; Deployment status shown as a badge in the badge row (like native &#x1F680; deployment badges). Clickable &mdash; opens DeployHQ dashboard. Deploy button stays in title row for re-deploying. Also works for deployments made outside PR Radar.</div>
+      </div>
+
+      <!-- State 6: Deploy error -->
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Refactor notification service</span>
+              <button class="action-btn merge-btn">Merge</button>
+              <span class="action-group">
+                <span class="error-inline" title="Deployment already running">Deploy already running</span>
+                <button class="action-btn cancel-btn">Dismiss</button>
+              </span>
+            </div>
+            <div class="pr-sub">
+              <span>deployhq/deployhq #1830</span>
+              <span class="tag tag-author">Author</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-gray">+55 -20</span>
+          <span class="time-ago">1d ago</span>
+        </div>
+        <div class="annotation">&#x2191; Error &mdash; Shows error message with Dismiss button</div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+<hr class="divider">
+
+<!-- ============================================ -->
+<!-- PR WITHOUT DEPLOYHQ -->
+<!-- ============================================ -->
+
+<div class="section-title" style="margin-bottom: 24px;">Dashboard &mdash; PR Without DeployHQ Project</div>
+
+<div class="single">
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">No matching project</span>
+      <span class="option-desc">&mdash; Deploy button does not appear</span>
+    </div>
+    <div class="option-body">
+      <div class="pr-item">
+        <div class="pr-row">
+          <svg class="gh-icon" viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+          <div class="pr-content">
+            <div class="pr-title-row">
+              <span class="pr-title">Update README with new API examples</span>
+              <button class="action-btn merge-btn">Merge</button>
+            </div>
+            <div class="pr-sub">
+              <span>acme/docs #42</span>
+              <span class="tag tag-review">Review</span>
+            </div>
+          </div>
+        </div>
+        <div class="badge-row">
+          <span class="badge badge-green">&#x2714; passed</span>
+          <span class="badge badge-gray">+30 -5</span>
+          <span class="time-ago">30m ago</span>
+        </div>
+      </div>
+      <div class="no-deploy-note">This repo has no matching DeployHQ project &mdash; no Deploy button shown. Same as current behavior.</div>
+    </div>
+  </div>
+</div>
+
+<hr class="divider">
+
+<!-- ============================================ -->
+<!-- SETTINGS IN CONTEXT -->
+<!-- ============================================ -->
+
+<div class="section-title" style="margin-bottom: 24px;">Settings &mdash; Full Page Context (Connected)</div>
+
+<div class="single">
+  <div class="option">
+    <div class="option-header">
+      <span class="option-label">Settings page</span>
+      <span class="option-desc">&mdash; DeployHQ section between Accounts and Community</span>
+    </div>
+    <div class="settings-section" style="border-bottom: 1px solid #1f1f35; padding-bottom: 12px;">
+      <div class="settings-title">Polling</div>
+      <div class="setting-row" style="border-bottom: none;">
+        <div>
+          <div class="setting-label">Check interval</div>
+        </div>
+        <select class="server-select" style="max-width: none; padding: 4px 8px; font-size: 11px;">
+          <option selected>1 minute</option>
+        </select>
+      </div>
+    </div>
+
+    <div class="settings-section" style="border-bottom: 1px solid #1f1f35; padding-bottom: 12px;">
+      <div class="settings-title">Accounts</div>
+      <div class="setting-row">
+        <div>
+          <div class="setting-label">GitHub</div>
+          <div class="setting-desc">@facundofarias</div>
+        </div>
+        <button class="btn-danger">Disconnect</button>
+      </div>
+      <div class="setting-row" style="border-bottom: none;">
+        <div>
+          <div class="setting-label">GitLab</div>
+          <div class="setting-desc">Not connected</div>
+        </div>
+        <span style="font-size: 11px; color: #7c6cc8; cursor: pointer;">Connect</span>
+      </div>
+    </div>
+
+    <!-- DeployHQ section highlighted -->
+    <div class="settings-section" style="border-bottom: 1px solid #1f1f35; padding-bottom: 12px;">
+      <div class="settings-title" style="color: #7c6cc8;">DeployHQ</div>
+      <div class="setting-row" style="border-bottom: none;">
+        <div>
+          <div class="setting-label">
+            <span class="connected-badge">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6L9 17l-5-5"/></svg>
+              Connected to Acme Corp
+            </span>
+          </div>
+          <div class="setting-desc">acme-corp.deployhq.com</div>
+        </div>
+        <button class="btn-danger">Disconnect</button>
+      </div>
+    </div>
+
+    <div class="settings-section">
+      <div class="settings-title" style="margin-top: 4px;">Community</div>
+      <div style="background: rgba(87, 64, 207, 0.05); border: 1px solid #2a2a3e; border-radius: 8px; padding: 10px 14px; margin-bottom: 8px;">
+        <div style="font-size: 13px; color: #e5e7eb;">&#128229; Share with your team</div>
+        <div style="font-size: 11px; color: #6b7280; margin-top: 2px;">Works best when your whole team uses it</div>
+      </div>
+      <div style="background: rgba(87, 64, 207, 0.05); border: 1px solid #2a2a3e; border-radius: 8px; padding: 10px 14px;">
+        <div style="font-size: 13px; color: #e5e7eb;">&#9733; Star us on GitHub</div>
+        <div style="font-size: 11px; color: #6b7280; margin-top: 2px;">Help others discover PR Radar</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+</body>
+</html>

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -333,7 +333,7 @@ async function pollPRs() {
         const mapping: Record<string, string> = {};
 
         for (const pr of allPRs) {
-          const project = deployhq.matchRepoToProject(pr.repoFullName, projects);
+          const project = deployhq.matchRepoToProject(pr.repoFullName, pr.platform, projects);
           if (project) {
             pr.deployhqProjectId = project.permalink;
             mapping[pr.repoFullName] = project.permalink;

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,9 +1,10 @@
 import type { PullRequest, CIStatus, Message } from '@/shared/types';
 import { CI_STATUS_LABELS } from '@/shared/constants';
-import { getSettings, getAccounts, getWatchedRepos, getCachedPRs, saveCachedPRs, setInstallDate } from '@/shared/storage';
+import { getSettings, getAccounts, getWatchedRepos, getCachedPRs, saveCachedPRs, setInstallDate, getDeployHQAccount, saveDeployHQAccount, getDeployHQRepoMapping, saveDeployHQRepoMapping } from '@/shared/storage';
 import * as github from '@/shared/api/github';
 import * as gitlab from '@/shared/api/gitlab';
 import * as bitbucket from '@/shared/api/bitbucket';
+import * as deployhq from '@/shared/api/deployhq';
 
 const ALARM_NAME = 'pr-radar-poll';
 const STATUS_CACHE_KEY = 'pr_radar_last_statuses';
@@ -109,6 +110,67 @@ chrome.runtime.onMessage.addListener((message: Message, _sender, sendResponse) =
     settings.then((s) => {
       if (s.soundEnabled) playSound(s.soundId, s.soundVolume);
     });
+  } else if (message.type === 'TEST_DEPLOYHQ') {
+    const { slug, email, apiKey } = message.payload;
+    (async () => {
+      const result = await deployhq.testConnection(slug, email, apiKey);
+      if (result.success) {
+        await saveDeployHQAccount({
+          slug,
+          email,
+          apiKey,
+          connected: true,
+          accountName: result.accountName,
+        });
+      }
+      sendResponse(result);
+    })();
+    return true;
+  } else if (message.type === 'GET_DEPLOYHQ_SERVERS') {
+    const { repoFullName } = message.payload;
+    (async () => {
+      const dhqAccount = await getDeployHQAccount();
+      if (!dhqAccount?.connected) {
+        sendResponse({ success: false, servers: [], message: 'DeployHQ not connected' });
+        return;
+      }
+      const mapping = await getDeployHQRepoMapping();
+      const permalink = mapping[repoFullName];
+      if (!permalink) {
+        sendResponse({ success: false, servers: [], message: 'No matching project' });
+        return;
+      }
+      try {
+        const servers = await deployhq.fetchServers(
+          dhqAccount.slug, dhqAccount.email, dhqAccount.apiKey, permalink,
+        );
+        sendResponse({ success: true, servers });
+      } catch (err) {
+        sendResponse({ success: false, servers: [], message: err instanceof Error ? err.message : 'Failed to fetch servers' });
+      }
+    })();
+    return true;
+  } else if (message.type === 'CREATE_DEPLOYHQ_DEPLOYMENT') {
+    const { repoFullName, serverIdentifier } = message.payload;
+    (async () => {
+      const dhqAccount = await getDeployHQAccount();
+      if (!dhqAccount?.connected) {
+        sendResponse({ success: false, message: 'DeployHQ not connected' });
+        return;
+      }
+      const mapping = await getDeployHQRepoMapping();
+      const permalink = mapping[repoFullName];
+      if (!permalink) {
+        sendResponse({ success: false, message: 'No matching project' });
+        return;
+      }
+      const result = await deployhq.createDeployment(
+        dhqAccount.slug, dhqAccount.email, dhqAccount.apiKey, permalink, serverIdentifier,
+      );
+      sendResponse(result);
+      if (result.success) pollPRs();
+    })();
+    return true;
   }
 });
 
@@ -258,6 +320,49 @@ async function pollPRs() {
           // GitLab/Bitbucket: keep merged PR with last-known CI status during TTL
           allPRs.push(pr);
         }
+      }
+    }
+
+    // Enrich PRs with DeployHQ project matching and deployment status
+    const dhqAccount = await getDeployHQAccount();
+    if (dhqAccount?.connected) {
+      try {
+        const projects = await deployhq.fetchProjects(
+          dhqAccount.slug, dhqAccount.email, dhqAccount.apiKey,
+        );
+        const mapping: Record<string, string> = {};
+
+        for (const pr of allPRs) {
+          const project = deployhq.matchRepoToProject(pr.repoFullName, projects);
+          if (project) {
+            pr.deployhqProjectId = project.permalink;
+            mapping[pr.repoFullName] = project.permalink;
+          }
+        }
+
+        await saveDeployHQRepoMapping(mapping);
+
+        // Fetch latest deployments for matched projects and set deployment status
+        const checkedPermalinks = new Set<string>();
+        const deploymentsByPermalink: Record<string, Array<{ endRevision: string; serverName: string; url: string }>> = {};
+
+        for (const pr of allPRs) {
+          if (!pr.deployhqProjectId || !pr.headSha) continue;
+          const permalink = pr.deployhqProjectId;
+          if (!checkedPermalinks.has(permalink)) {
+            checkedPermalinks.add(permalink);
+            deploymentsByPermalink[permalink] = await deployhq.fetchLatestDeployments(
+              dhqAccount.slug, dhqAccount.email, dhqAccount.apiKey, permalink,
+            );
+          }
+          const deployments = deploymentsByPermalink[permalink] || [];
+          const match = deployments.find((d) => d.endRevision === pr.headSha);
+          if (match) {
+            pr.deployhqDeployment = { serverName: match.serverName, url: match.url };
+          }
+        }
+      } catch (err) {
+        console.error('[PR Radar] DeployHQ enrichment failed:', err);
       }
     }
 

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { PullRequest, Message } from '@/shared/types';
+import type { PullRequest, Message, DeployHQServer } from '@/shared/types';
 import CIBadge from './CIBadge';
 import PlatformIcon from './PlatformIcon';
 
@@ -16,6 +16,10 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
   const [mergeError, setMergeError] = useState('');
   const [branchState, setBranchState] = useState<'idle' | 'confirm' | 'deleting' | 'deleted' | 'error'>('idle');
   const [branchError, setBranchError] = useState('');
+  const [deployState, setDeployState] = useState<'idle' | 'loading' | 'selecting' | 'deploying' | 'deployed' | 'error'>('idle');
+  const [deployError, setDeployError] = useState('');
+  const [servers, setServers] = useState<DeployHQServer[]>([]);
+  const [selectedServer, setSelectedServer] = useState('');
   const [expanded, setExpanded] = useState(false);
   const description = pr.description?.trim();
   const timeAgo = getTimeAgo(pr.updatedAt);
@@ -58,6 +62,51 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
     } catch {
       setBranchError('Failed to delete branch');
       setBranchState('error');
+    }
+  }
+
+  async function handleDeployClick() {
+    setDeployState('loading');
+    setDeployError('');
+    try {
+      const result = await chrome.runtime.sendMessage({
+        type: 'GET_DEPLOYHQ_SERVERS',
+        payload: { repoFullName: pr.repoFullName },
+      } satisfies Message) as { success: boolean; servers: DeployHQServer[]; message?: string };
+      if (result.success && result.servers.length > 0) {
+        setServers(result.servers);
+        setSelectedServer(result.servers[0].identifier);
+        setDeployState('selecting');
+      } else {
+        setDeployError(result.message || 'No servers found');
+        setDeployState('error');
+      }
+    } catch {
+      setDeployError('Failed to fetch servers');
+      setDeployState('error');
+    }
+  }
+
+  async function handleDeploy() {
+    if (!selectedServer) return;
+    const server = servers.find((s) => s.identifier === selectedServer);
+    if (!server) return;
+    setDeployState('deploying');
+    setDeployError('');
+    try {
+      const result = await chrome.runtime.sendMessage({
+        type: 'CREATE_DEPLOYHQ_DEPLOYMENT',
+        payload: { repoFullName: pr.repoFullName, serverIdentifier: server.identifier, serverType: server.serverType },
+      } satisfies Message) as { success: boolean; message: string };
+      if (result.success) {
+        setDeployState('deployed');
+      } else {
+        setDeployError(result.message);
+        setDeployState('error');
+      }
+    } catch {
+      setDeployError('Failed to create deployment');
+      setDeployState('error');
     }
   }
 
@@ -197,6 +246,75 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
                   Reviewed
                 </span>
               )}
+              {pr.deployhqProjectId && (
+                <span className="ml-auto flex items-center gap-1">
+                  {deployState === 'idle' && (
+                    <button
+                      onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleDeployClick(); }}
+                      title="Deploy with DeployHQ"
+                      className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#5740cf] text-white border-[#6b54d9] hover:bg-[#6b54d9] cursor-pointer transition-colors"
+                    >
+                      Deploy
+                    </button>
+                  )}
+                  {deployState === 'loading' && (
+                    <span className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#21262d] text-[#a78bfa] border-[#30363d]" role="status" aria-label="Loading servers">
+                      <span className="inline-block w-2.5 h-2.5 border-[1.5px] border-[#a78bfa]/30 border-t-[#a78bfa] rounded-full animate-spin align-middle" />
+                    </span>
+                  )}
+                  {deployState === 'selecting' && (
+                    <>
+                      <select
+                        value={selectedServer}
+                        onChange={(e) => { e.stopPropagation(); setSelectedServer(e.target.value); }}
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                        className="bg-gray-50 dark:bg-[#12121e] border border-gray-300 dark:border-[#2a2a3e] rounded-md px-1 py-0.5 text-[10px] text-gray-800 dark:text-gray-200 max-w-[140px]"
+                        aria-label="Select server"
+                      >
+                        {servers.map((s) => (
+                          <option key={s.identifier} value={s.identifier}>
+                            {s.name}{s.serverType === 'server_group' ? ' (Group)' : ''}
+                          </option>
+                        ))}
+                      </select>
+                      <button
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleDeploy(); }}
+                        className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#5740cf] text-white border-[#6b54d9] hover:bg-[#6b54d9] cursor-pointer transition-colors"
+                      >
+                        Deploy
+                      </button>
+                      <button
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); setDeployState('idle'); }}
+                        className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#21262d] text-[#c9d1d9] border-[#30363d] hover:bg-[#30363d] cursor-pointer transition-colors"
+                      >
+                        Cancel
+                      </button>
+                    </>
+                  )}
+                  {deployState === 'deploying' && (
+                    <span className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#21262d] text-[#a78bfa] border-[#30363d]" role="status" aria-label="Deploying">
+                      <span className="inline-block w-2.5 h-2.5 border-[1.5px] border-[#a78bfa]/30 border-t-[#a78bfa] rounded-full animate-spin align-middle mr-1" />
+                      Deploying...
+                    </span>
+                  )}
+                  {deployState === 'deployed' && (
+                    <span className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#5740cf] text-white border-[#5740cf]">
+                      &#x2714; Deployed
+                    </span>
+                  )}
+                  {deployState === 'error' && (
+                    <>
+                      <span className="text-[10px] text-red-400 truncate max-w-[120px]" title={deployError}>{deployError}</span>
+                      <button
+                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); setDeployState('idle'); }}
+                        className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#21262d] text-[#c9d1d9] border-[#30363d] hover:bg-[#30363d] cursor-pointer transition-colors"
+                      >
+                        Dismiss
+                      </button>
+                    </>
+                  )}
+                </span>
+              )}
             </div>
           </div>
         </div>
@@ -254,6 +372,21 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
             }>
               <span aria-hidden="true">&#x1F680;</span> <span aria-label={`Deployment ${pr.deployment.status}: ${pr.deployment.environment}`}>{pr.deployment.environment}</span>
             </Badge>
+          )}
+
+          {pr.deployhqDeployment && (
+            <a
+              href={pr.deployhqDeployment.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
+              title={`Deployed to ${pr.deployhqDeployment.serverName} \u2014 View in DeployHQ`}
+              aria-label={`Deployed to ${pr.deployhqDeployment.serverName}`}
+            >
+              <Badge className="bg-[#5740cf]/15 text-[#a78bfa] hover:bg-[#5740cf]/25 cursor-pointer transition-colors">
+                <span aria-hidden="true">&#x1F680;</span> {pr.deployhqDeployment.serverName}
+              </Badge>
+            </a>
           )}
 
           {(pr.additions !== undefined || pr.deletions !== undefined) && (

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -96,7 +96,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
     try {
       const result = await chrome.runtime.sendMessage({
         type: 'CREATE_DEPLOYHQ_DEPLOYMENT',
-        payload: { repoFullName: pr.repoFullName, serverIdentifier: server.identifier, serverType: server.serverType },
+        payload: { repoFullName: pr.repoFullName, serverIdentifier: server.identifier },
       } satisfies Message) as { success: boolean; message: string };
       if (result.success) {
         setDeployState('deployed');

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -134,7 +134,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
                   title={!isMergeable
                     ? [pr.isDraft && 'Draft PR', pr.hasConflicts && 'Has conflicts', pr.ciStatus === 'failed' && 'CI is failing'].filter(Boolean).join(', ')
                     : 'Merge pull request'}
-                  className={`flex-shrink-0 text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border transition-colors ${
+                  className={`flex-shrink-0 text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border transition-colors w-[52px] text-center ${
                     isMergeable
                       ? 'bg-[#238636] text-white border-[#2ea043] hover:bg-[#2ea043] cursor-pointer'
                       : 'bg-[#21262d] text-[#484f58] border-[#30363d] cursor-not-allowed'
@@ -252,7 +252,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
                     <button
                       onClick={(e) => { e.preventDefault(); e.stopPropagation(); handleDeployClick(); }}
                       title="Deploy with DeployHQ"
-                      className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#5740cf] text-white border-[#6b54d9] hover:bg-[#6b54d9] cursor-pointer transition-colors"
+                      className="text-[10px] leading-none px-2 py-0.5 rounded-md font-semibold border bg-[#5740cf] text-white border-[#6b54d9] hover:bg-[#6b54d9] cursor-pointer transition-colors w-[52px] text-center"
                     >
                       Deploy
                     </button>

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
-import type { AppView, Platform } from '@/shared/types';
+import type { AppView, Platform, DeployHQAccount } from '@/shared/types';
 import { PLATFORM_LABELS, SOUND_OPTIONS } from '@/shared/constants';
-import { getSettings, saveSettings, getAccounts, removeAccount, type Settings as SettingsType, type ThemeMode } from '@/shared/storage';
+import { getSettings, saveSettings, getAccounts, removeAccount, getDeployHQAccount, removeDeployHQAccount, type Settings as SettingsType, type ThemeMode } from '@/shared/storage';
 import { STORE_URL, GITHUB_REPO_URL, GITHUB_ISSUES_URL } from '@/shared/constants';
 
 interface SettingsProps {
@@ -14,11 +14,26 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
   const [settings, setSettings] = useState<SettingsType | null>(null);
   const [connectedPlatforms, setConnectedPlatforms] = useState<{ platform: Platform; username: string }[]>([]);
 
+  // DeployHQ state
+  const [dhqAccount, setDhqAccount] = useState<DeployHQAccount | null>(null);
+  const [dhqSlug, setDhqSlug] = useState('');
+  const [dhqEmail, setDhqEmail] = useState('');
+  const [dhqApiKey, setDhqApiKey] = useState('');
+  const [dhqTesting, setDhqTesting] = useState(false);
+  const [dhqError, setDhqError] = useState('');
+  const [dhqExpanded, setDhqExpanded] = useState(false);
+
   useEffect(() => {
     async function load() {
-      const [s, accounts] = await Promise.all([getSettings(), getAccounts()]);
+      const [s, accounts, dhq] = await Promise.all([getSettings(), getAccounts(), getDeployHQAccount()]);
       setSettings(s);
       setConnectedPlatforms(accounts.map((a) => ({ platform: a.platform, username: a.username })));
+      if (dhq) {
+        setDhqAccount(dhq);
+        setDhqSlug(dhq.slug);
+        setDhqEmail(dhq.email);
+        setDhqApiKey(dhq.apiKey);
+      }
     }
     load();
   }, []);
@@ -210,6 +225,129 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
               </button>
             </SettingRow>
           ))}
+        {dhqAccount?.connected ? (
+          <SettingRow
+            label="DeployHQ"
+            description={`${dhqAccount.slug}.deployhq.com`}
+          >
+            <button
+              onClick={async () => {
+                await removeDeployHQAccount();
+                setDhqAccount(null);
+                setDhqSlug('');
+                setDhqEmail('');
+                setDhqApiKey('');
+                setDhqError('');
+                setDhqExpanded(false);
+              }}
+              className="text-[11px] text-gray-500 hover:text-red-400 transition-colors"
+            >
+              Disconnect
+            </button>
+          </SettingRow>
+        ) : (
+          <>
+            <SettingRow
+              label="DeployHQ"
+              description="Not connected"
+            >
+              <button
+                onClick={() => setDhqExpanded(!dhqExpanded)}
+                className="text-[11px] text-radar-400 hover:underline"
+              >
+                {dhqExpanded ? 'Cancel' : 'Connect'}
+              </button>
+            </SettingRow>
+            {dhqExpanded && (
+              <div className="py-3 border-b border-gray-200 dark:border-gray-800">
+                <div className="space-y-2.5">
+                  <div>
+                    <label className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Account</label>
+                    <div className="flex items-center gap-1">
+                      <input
+                        type="text"
+                        value={dhqSlug}
+                        onChange={(e) => { setDhqSlug(e.target.value); setDhqError(''); }}
+                        placeholder="my-company"
+                        disabled={dhqTesting}
+                        className="bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md px-2 py-1 text-xs text-gray-800 dark:text-gray-200 w-[130px] disabled:opacity-50"
+                      />
+                      <span className="text-[11px] text-gray-500">.deployhq.com</span>
+                    </div>
+                  </div>
+                  <div>
+                    <label className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Email</label>
+                    <input
+                      type="email"
+                      value={dhqEmail}
+                      onChange={(e) => { setDhqEmail(e.target.value); setDhqError(''); }}
+                      placeholder="you@company.com"
+                      disabled={dhqTesting}
+                      className="bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md px-2 py-1 text-xs text-gray-800 dark:text-gray-200 w-full disabled:opacity-50"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">API key</label>
+                    <input
+                      type="password"
+                      value={dhqApiKey}
+                      onChange={(e) => { setDhqApiKey(e.target.value); setDhqError(''); }}
+                      placeholder="Your API key"
+                      disabled={dhqTesting}
+                      className="bg-gray-50 dark:bg-gray-800 border border-gray-300 dark:border-gray-700 rounded-md px-2 py-1 text-xs text-gray-800 dark:text-gray-200 w-full disabled:opacity-50"
+                    />
+                  </div>
+                </div>
+                <p className="text-[11px] text-gray-500 mt-2">
+                  Find your API key in{' '}
+                  <span className="text-radar-400">Settings &#8594; Security</span>
+                  {' '}in DeployHQ
+                </p>
+                {dhqError && (
+                  <p className="text-[11px] text-red-400 mt-1.5">{dhqError}</p>
+                )}
+                <button
+                  onClick={async () => {
+                    if (!dhqSlug || !dhqEmail || !dhqApiKey) {
+                      setDhqError('All fields are required');
+                      return;
+                    }
+                    setDhqTesting(true);
+                    setDhqError('');
+                    try {
+                      const result = await chrome.runtime.sendMessage({
+                        type: 'TEST_DEPLOYHQ',
+                        payload: { slug: dhqSlug, email: dhqEmail, apiKey: dhqApiKey },
+                      }) as { success: boolean; accountName?: string; message?: string };
+                      if (result.success) {
+                        setDhqAccount({
+                          slug: dhqSlug,
+                          email: dhqEmail,
+                          apiKey: dhqApiKey,
+                          connected: true,
+                          accountName: result.accountName,
+                        });
+                        setDhqExpanded(false);
+                      } else {
+                        setDhqError(result.message || 'Connection failed');
+                      }
+                    } catch (err) {
+                      setDhqError(err instanceof Error ? err.message : 'Failed to connect');
+                    }
+                    setDhqTesting(false);
+                  }}
+                  disabled={dhqTesting}
+                  className="mt-3 text-[11px] px-3 py-1.5 rounded-md font-semibold bg-[#5740cf] text-white border border-[#6b54d9] hover:bg-[#6b54d9] transition-colors disabled:opacity-60 disabled:cursor-wait flex items-center gap-1.5"
+                >
+                  {dhqTesting && (
+                    <span className="inline-block w-3 h-3 border-2 border-white/30 border-t-white rounded-full animate-spin" />
+                  )}
+                  {dhqTesting ? 'Connecting...' : 'Connect'}
+                </button>
+              </div>
+            )}
+          </>
+        )}
       </Section>
 
       {/* Community */}

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -252,6 +252,8 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
               description="Not connected"
             >
               <button
+                aria-expanded={dhqExpanded}
+                aria-controls="deployhq-connect-form"
                 onClick={() => setDhqExpanded(!dhqExpanded)}
                 className="text-[11px] text-radar-400 hover:underline"
               >
@@ -259,7 +261,7 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
               </button>
             </SettingRow>
             {dhqExpanded && (
-              <div className="py-3 border-b border-gray-200 dark:border-gray-800">
+              <div id="deployhq-connect-form" className="py-3 border-b border-gray-200 dark:border-gray-800">
                 <div className="space-y-2.5">
                   <div>
                     <label htmlFor="dhq-slug" className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Account</label>
@@ -307,7 +309,7 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
                   {' '}in DeployHQ
                 </p>
                 {dhqError && (
-                  <p className="text-[11px] text-red-400 mt-1.5">{dhqError}</p>
+                  <p role="alert" className="text-[11px] text-red-400 mt-1.5">{dhqError}</p>
                 )}
                 <button
                   onClick={async () => {

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -262,9 +262,10 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
               <div className="py-3 border-b border-gray-200 dark:border-gray-800">
                 <div className="space-y-2.5">
                   <div>
-                    <label className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Account</label>
+                    <label htmlFor="dhq-slug" className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Account</label>
                     <div className="flex items-center gap-1">
                       <input
+                        id="dhq-slug"
                         type="text"
                         value={dhqSlug}
                         onChange={(e) => { setDhqSlug(e.target.value); setDhqError(''); }}
@@ -276,8 +277,9 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
                     </div>
                   </div>
                   <div>
-                    <label className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Email</label>
+                    <label htmlFor="dhq-email" className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">Email</label>
                     <input
+                      id="dhq-email"
                       type="email"
                       value={dhqEmail}
                       onChange={(e) => { setDhqEmail(e.target.value); setDhqError(''); }}
@@ -287,8 +289,9 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
                     />
                   </div>
                   <div>
-                    <label className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">API key</label>
+                    <label htmlFor="dhq-api-key" className="block text-[12px] text-gray-500 dark:text-gray-400 mb-1">API key</label>
                     <input
+                      id="dhq-api-key"
                       type="password"
                       value={dhqApiKey}
                       onChange={(e) => { setDhqApiKey(e.target.value); setDhqError(''); }}

--- a/src/shared/api/deployhq.test.ts
+++ b/src/shared/api/deployhq.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { extractRepoPath, extractRepoHost, matchRepoToProject, testConnection, fetchServers } from './deployhq';
+import type { DeployHQProject } from '../types';
+
+function project(name: string, repoUrl: string): DeployHQProject {
+  return { identifier: name, name, permalink: name, repoUrl };
+}
+
+describe('extractRepoPath', () => {
+  it('extracts path from HTTPS URLs', () => {
+    expect(extractRepoPath('https://github.com/deployhq/pr-radar.git')).toBe('deployhq/pr-radar');
+  });
+
+  it('extracts path from SSH URLs', () => {
+    expect(extractRepoPath('git@github.com:deployhq/pr-radar.git')).toBe('deployhq/pr-radar');
+  });
+
+  it('handles URLs without .git suffix', () => {
+    expect(extractRepoPath('https://github.com/deployhq/pr-radar')).toBe('deployhq/pr-radar');
+  });
+
+  it('handles SSH URLs without .git suffix', () => {
+    expect(extractRepoPath('git@github.com:deployhq/pr-radar')).toBe('deployhq/pr-radar');
+  });
+
+  it('handles GitLab SSH URLs with nested groups', () => {
+    expect(extractRepoPath('git@gitlab.com:org/subgroup/project.git')).toBe('org/subgroup/project');
+  });
+
+  it('handles Codebase HQ URLs', () => {
+    expect(extractRepoPath('git@codebasehq.com:awesome/project/example.git')).toBe('awesome/project/example');
+  });
+
+  it('handles HTTPS URLs with trailing slash', () => {
+    expect(extractRepoPath('https://github.com/deployhq/pr-radar/')).toBe('deployhq/pr-radar');
+  });
+
+  it('handles SSH protocol URLs', () => {
+    expect(extractRepoPath('ssh://git@github.com/deployhq/pr-radar.git')).toBe('deployhq/pr-radar');
+  });
+
+  it('is case-insensitive', () => {
+    expect(extractRepoPath('https://github.com/DeployHQ/PR-Radar.git')).toBe('deployhq/pr-radar');
+  });
+});
+
+describe('extractRepoHost', () => {
+  it('extracts host from HTTPS URLs', () => {
+    expect(extractRepoHost('https://github.com/deployhq/pr-radar.git')).toBe('github.com');
+  });
+
+  it('extracts host from SSH URLs', () => {
+    expect(extractRepoHost('git@github.com:deployhq/pr-radar.git')).toBe('github.com');
+  });
+
+  it('extracts host from GitLab URLs', () => {
+    expect(extractRepoHost('git@gitlab.com:org/project.git')).toBe('gitlab.com');
+  });
+
+  it('extracts host from Bitbucket URLs', () => {
+    expect(extractRepoHost('https://bitbucket.org/team/repo.git')).toBe('bitbucket.org');
+  });
+});
+
+describe('matchRepoToProject', () => {
+  const projects = [
+    project('pr-radar', 'git@github.com:deployhq/pr-radar.git'),
+    project('website', 'https://github.com/deployhq/website.git'),
+    project('billy', 'git@gitlab.com:deployhq/billy.git'),
+  ];
+
+  it('matches SSH URL to repoFullName', () => {
+    const result = matchRepoToProject('deployhq/pr-radar', 'github', projects);
+    expect(result).not.toBeNull();
+    expect(result!.permalink).toBe('pr-radar');
+  });
+
+  it('matches HTTPS URL to repoFullName', () => {
+    const result = matchRepoToProject('deployhq/website', 'github', projects);
+    expect(result).not.toBeNull();
+    expect(result!.permalink).toBe('website');
+  });
+
+  it('matches case-insensitively', () => {
+    const result = matchRepoToProject('DeployHQ/PR-Radar', 'github', projects);
+    expect(result).not.toBeNull();
+    expect(result!.permalink).toBe('pr-radar');
+  });
+
+  it('returns null when no project matches', () => {
+    expect(matchRepoToProject('deployhq/unknown-repo', 'github', projects)).toBeNull();
+  });
+
+  it('returns null for empty project list', () => {
+    expect(matchRepoToProject('deployhq/pr-radar', 'github', [])).toBeNull();
+  });
+
+  it('matches GitLab repos against GitLab projects', () => {
+    const result = matchRepoToProject('deployhq/billy', 'gitlab', projects);
+    expect(result).not.toBeNull();
+    expect(result!.permalink).toBe('billy');
+  });
+
+  it('prevents cross-provider collision (same owner/repo on different hosts)', () => {
+    const mixedProjects = [
+      project('gh-app', 'git@github.com:acme/app.git'),
+      project('gl-app', 'git@gitlab.com:acme/app.git'),
+    ];
+
+    const ghResult = matchRepoToProject('acme/app', 'github', mixedProjects);
+    expect(ghResult).not.toBeNull();
+    expect(ghResult!.permalink).toBe('gh-app');
+
+    const glResult = matchRepoToProject('acme/app', 'gitlab', mixedProjects);
+    expect(glResult).not.toBeNull();
+    expect(glResult!.permalink).toBe('gl-app');
+  });
+
+  it('does not match GitHub repo against GitLab project', () => {
+    const result = matchRepoToProject('deployhq/billy', 'github', projects);
+    expect(result).toBeNull();
+  });
+});
+
+describe('testConnection', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns success with account name on valid credentials', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ company_name: 'Acme Corp' }));
+
+    const result = await testConnection('acme', 'user@acme.com', 'key123');
+
+    expect(result.success).toBe(true);
+    expect(result.accountName).toBe('Acme Corp');
+  });
+
+  it('returns failure on 401', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+      text: async () => 'Unauthorized',
+    } as Response);
+
+    const result = await testConnection('acme', 'wrong@acme.com', 'badkey');
+
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('401');
+  });
+
+  it('sends correct auth header', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ company_name: 'Test' }));
+
+    await testConnection('myslug', 'me@test.com', 'apikey');
+
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledWith(
+      'https://myslug.deployhq.com/account',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: `Basic ${btoa('me@test.com:apikey')}`,
+        }),
+      }),
+    );
+  });
+});
+
+describe('fetchServers', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('combines servers and server groups', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    // First call: servers
+    fetchMock.mockResolvedValueOnce(jsonResponse([
+      { identifier: 's1', name: 'Production' },
+      { identifier: 's2', name: 'Staging' },
+    ]));
+    // Second call: server groups
+    fetchMock.mockResolvedValueOnce(jsonResponse([
+      { identifier: 'g1', name: 'All Servers' },
+    ]));
+
+    const result = await fetchServers('acme', 'user@acme.com', 'key', 'my-project');
+
+    expect(result).toEqual([
+      { identifier: 'g1', name: 'All Servers', serverType: 'server_group' },
+      { identifier: 's1', name: 'Production', serverType: 'server' },
+      { identifier: 's2', name: 'Staging', serverType: 'server' },
+    ]);
+  });
+
+  it('returns empty array when both endpoints fail', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+    fetchMock.mockRejectedValueOnce(new Error('fail'));
+    fetchMock.mockRejectedValueOnce(new Error('fail'));
+
+    const result = await fetchServers('acme', 'user@acme.com', 'key', 'my-project');
+
+    expect(result).toEqual([]);
+  });
+});
+
+function jsonResponse(body: unknown): Response {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: async () => body,
+    headers: {
+      get: () => null,
+    },
+  } as unknown as Response;
+}

--- a/src/shared/api/deployhq.ts
+++ b/src/shared/api/deployhq.ts
@@ -110,16 +110,17 @@ export function extractRepoHost(url: string): string {
     return cleaned.toLowerCase();
   }
 
-  // Strip protocol
+  // Strip protocol and user@
   cleaned = cleaned.replace(/^(https?:\/\/|ssh:\/\/)/, '');
+  cleaned = cleaned.replace(/^[^@]+@/, '');
 
-  // Extract host (everything before first /)
+  // Extract host (everything before first /), strip port
   const slashIdx = cleaned.indexOf('/');
   if (slashIdx > 0) {
-    return cleaned.substring(0, slashIdx).toLowerCase();
+    return cleaned.substring(0, slashIdx).replace(/:\d+$/, '').toLowerCase();
   }
 
-  return cleaned.toLowerCase();
+  return cleaned.replace(/:\d+$/, '').toLowerCase();
 }
 
 export function extractRepoPath(url: string): string {
@@ -165,7 +166,7 @@ export function matchRepoToProject(
 
     // Verify the host matches the platform to avoid cross-provider collisions
     const projectHost = extractRepoHost(project.repoUrl);
-    if (platformHosts.some((h) => projectHost.includes(h))) {
+    if (platformHosts.includes(projectHost)) {
       return project;
     }
   }

--- a/src/shared/api/deployhq.ts
+++ b/src/shared/api/deployhq.ts
@@ -1,0 +1,253 @@
+import type { DeployHQProject, DeployHQServer } from '../types';
+
+// === Base fetch helper ===
+
+async function dhqFetch<T>(
+  slug: string,
+  path: string,
+  email: string,
+  apiKey: string,
+  options?: RequestInit,
+): Promise<T> {
+  const url = `https://${slug}.deployhq.com${path}`;
+  const response = await fetch(url, {
+    ...options,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${btoa(`${email}:${apiKey}`)}`,
+      ...options?.headers,
+    },
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`DeployHQ API ${response.status}: ${text || response.statusText}`);
+  }
+  return response.json();
+}
+
+// === Connection test ===
+
+export async function testConnection(
+  slug: string,
+  email: string,
+  apiKey: string,
+): Promise<{ success: boolean; accountName?: string; message?: string }> {
+  try {
+    const account = await dhqFetch<{ company_name?: string; name?: string }>(
+      slug, '/account', email, apiKey,
+    );
+    return {
+      success: true,
+      accountName: account.company_name || account.name || slug,
+    };
+  } catch (err) {
+    return {
+      success: false,
+      message: err instanceof Error ? err.message : 'Connection failed',
+    };
+  }
+}
+
+// === Projects ===
+
+// GET /projects returns basic fields: name, permalink, last_deployed_at
+interface RawProjectBasic {
+  name: string;
+  permalink: string;
+}
+
+// GET /projects/{permalink} returns full fields including nested repository
+interface RawProjectFull {
+  name: string;
+  permalink: string;
+  repository?: {
+    url?: string;
+    scm_type?: string;
+    branch?: string;
+  };
+}
+
+export async function fetchProjects(
+  slug: string,
+  email: string,
+  apiKey: string,
+): Promise<DeployHQProject[]> {
+  const projects = await dhqFetch<RawProjectBasic[]>(slug, '/projects', email, apiKey);
+  const results: DeployHQProject[] = [];
+
+  // Fetch full project details to get repository URL
+  for (const project of projects) {
+    try {
+      const full = await dhqFetch<RawProjectFull>(
+        slug, `/projects/${project.permalink}`, email, apiKey,
+      );
+      const repoUrl = full.repository?.url || '';
+      if (repoUrl) {
+        results.push({
+          identifier: project.permalink,
+          name: full.name,
+          permalink: project.permalink,
+          repoUrl,
+        });
+      }
+    } catch {
+      // Project may not have a repository configured — skip
+    }
+  }
+
+  return results;
+}
+
+// === Repo matching ===
+
+function normalizeRepoPath(url: string): string {
+  let path = url;
+
+  // Handle SSH URLs: git@github.com:owner/repo.git → github.com/owner/repo
+  if (path.includes('@') && path.includes(':') && !path.includes('://')) {
+    path = path.replace(/^.*@/, '').replace(':', '/');
+  }
+
+  // Strip protocol
+  path = path.replace(/^(https?:\/\/|ssh:\/\/)/, '');
+
+  // Strip .git suffix and trailing slashes
+  path = path.replace(/\.git\/?$/, '').replace(/\/$/, '');
+
+  // Remove host portion (e.g., "github.com/owner/repo" → "owner/repo")
+  const slashIdx = path.indexOf('/');
+  if (slashIdx > 0) {
+    path = path.substring(slashIdx + 1);
+  }
+
+  return path.toLowerCase();
+}
+
+export function matchRepoToProject(
+  repoFullName: string,
+  projects: DeployHQProject[],
+): DeployHQProject | null {
+  const normalizedRepo = repoFullName.toLowerCase();
+
+  for (const project of projects) {
+    const normalizedProjectRepo = normalizeRepoPath(project.repoUrl);
+    if (normalizedProjectRepo === normalizedRepo) {
+      return project;
+    }
+  }
+
+  return null;
+}
+
+// === Servers ===
+
+interface RawServer {
+  identifier: string;
+  name: string;
+}
+
+interface RawServerGroup {
+  identifier: string;
+  name: string;
+}
+
+export async function fetchServers(
+  slug: string,
+  email: string,
+  apiKey: string,
+  projectPermalink: string,
+): Promise<DeployHQServer[]> {
+  const [servers, groups] = await Promise.all([
+    dhqFetch<RawServer[]>(slug, `/projects/${projectPermalink}/servers`, email, apiKey)
+      .catch(() => [] as RawServer[]),
+    dhqFetch<RawServerGroup[]>(slug, `/projects/${projectPermalink}/server_groups`, email, apiKey)
+      .catch(() => [] as RawServerGroup[]),
+  ]);
+
+  const result: DeployHQServer[] = [];
+
+  for (const group of groups) {
+    result.push({
+      identifier: group.identifier,
+      name: group.name,
+      serverType: 'server_group',
+    });
+  }
+
+  for (const server of servers) {
+    result.push({
+      identifier: server.identifier,
+      name: server.name,
+      serverType: 'server',
+    });
+  }
+
+  return result;
+}
+
+// === Deployments ===
+
+interface RawDeployment {
+  identifier: string;
+  status: string;
+  end_revision?: string;
+}
+
+export async function createDeployment(
+  slug: string,
+  email: string,
+  apiKey: string,
+  projectPermalink: string,
+  parentIdentifier: string,
+): Promise<{ success: boolean; message: string }> {
+  try {
+    await dhqFetch<RawDeployment>(
+      slug,
+      `/projects/${projectPermalink}/deployments`,
+      email,
+      apiKey,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          deployment: {
+            parent_identifier: parentIdentifier,
+            mode: 'queue',
+          },
+        }),
+      },
+    );
+    return { success: true, message: 'Deployment queued' };
+  } catch (err) {
+    return {
+      success: false,
+      message: err instanceof Error ? err.message : 'Failed to create deployment',
+    };
+  }
+}
+
+// Deployment list returns basic fields only (no nested server/target info).
+// We match by server's last_revision instead.
+export async function fetchLatestDeployments(
+  slug: string,
+  email: string,
+  apiKey: string,
+  projectPermalink: string,
+): Promise<Array<{ endRevision: string; serverName: string; url: string }>> {
+  try {
+    // Fetch servers to get last_revision per server
+    const servers = await dhqFetch<Array<{ identifier: string; name: string; last_revision?: string }>>(
+      slug, `/projects/${projectPermalink}/servers`, email, apiKey,
+    ).catch(() => []);
+
+    return servers
+      .filter((s) => s.last_revision)
+      .map((s) => ({
+        endRevision: s.last_revision!,
+        serverName: s.name,
+        url: `https://${slug}.deployhq.com/projects/${projectPermalink}`,
+      }));
+  } catch {
+    return [];
+  }
+}

--- a/src/shared/api/deployhq.ts
+++ b/src/shared/api/deployhq.ts
@@ -1,4 +1,4 @@
-import type { DeployHQProject, DeployHQServer } from '../types';
+import type { DeployHQProject, DeployHQServer, Platform } from '../types';
 
 // === Base fetch helper ===
 
@@ -101,7 +101,28 @@ export async function fetchProjects(
 
 // === Repo matching ===
 
-function normalizeRepoPath(url: string): string {
+export function extractRepoHost(url: string): string {
+  let cleaned = url;
+
+  // Handle SSH URLs: git@github.com:owner/repo → github.com
+  if (cleaned.includes('@') && cleaned.includes(':') && !cleaned.includes('://')) {
+    cleaned = cleaned.replace(/^.*@/, '').replace(/:.*$/, '');
+    return cleaned.toLowerCase();
+  }
+
+  // Strip protocol
+  cleaned = cleaned.replace(/^(https?:\/\/|ssh:\/\/)/, '');
+
+  // Extract host (everything before first /)
+  const slashIdx = cleaned.indexOf('/');
+  if (slashIdx > 0) {
+    return cleaned.substring(0, slashIdx).toLowerCase();
+  }
+
+  return cleaned.toLowerCase();
+}
+
+export function extractRepoPath(url: string): string {
   let path = url;
 
   // Handle SSH URLs: git@github.com:owner/repo.git → github.com/owner/repo
@@ -124,15 +145,27 @@ function normalizeRepoPath(url: string): string {
   return path.toLowerCase();
 }
 
+const PLATFORM_HOSTS: Record<Platform, string[]> = {
+  github: ['github.com'],
+  gitlab: ['gitlab.com'],
+  bitbucket: ['bitbucket.org'],
+};
+
 export function matchRepoToProject(
   repoFullName: string,
+  platform: Platform,
   projects: DeployHQProject[],
 ): DeployHQProject | null {
   const normalizedRepo = repoFullName.toLowerCase();
+  const platformHosts = PLATFORM_HOSTS[platform];
 
   for (const project of projects) {
-    const normalizedProjectRepo = normalizeRepoPath(project.repoUrl);
-    if (normalizedProjectRepo === normalizedRepo) {
+    const projectPath = extractRepoPath(project.repoUrl);
+    if (projectPath !== normalizedRepo) continue;
+
+    // Verify the host matches the platform to avoid cross-provider collisions
+    const projectHost = extractRepoHost(project.repoUrl);
+    if (platformHosts.some((h) => projectHost.includes(h))) {
       return project;
     }
   }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,4 +1,4 @@
-import type { PlatformAccount, WatchedRepo, Platform } from './types';
+import type { PlatformAccount, WatchedRepo, Platform, DeployHQAccount } from './types';
 import type { SoundId } from './constants';
 
 const ACCOUNTS_KEY = 'pr_radar_accounts';
@@ -106,6 +106,33 @@ export async function saveCachedPRs(prs: PullRequest[]): Promise<void> {
   });
 }
 
+// === DeployHQ ===
+
+const DEPLOYHQ_ACCOUNT_KEY = 'pr_radar_deployhq';
+const DEPLOYHQ_MAPPING_KEY = 'pr_radar_deployhq_mapping';
+
+export async function getDeployHQAccount(): Promise<DeployHQAccount | null> {
+  const result = await chrome.storage.local.get(DEPLOYHQ_ACCOUNT_KEY);
+  return result[DEPLOYHQ_ACCOUNT_KEY] ?? null;
+}
+
+export async function saveDeployHQAccount(account: DeployHQAccount): Promise<void> {
+  await chrome.storage.local.set({ [DEPLOYHQ_ACCOUNT_KEY]: account });
+}
+
+export async function removeDeployHQAccount(): Promise<void> {
+  await chrome.storage.local.remove([DEPLOYHQ_ACCOUNT_KEY, DEPLOYHQ_MAPPING_KEY]);
+}
+
+export async function getDeployHQRepoMapping(): Promise<Record<string, string>> {
+  const result = await chrome.storage.local.get(DEPLOYHQ_MAPPING_KEY);
+  return result[DEPLOYHQ_MAPPING_KEY] ?? {};
+}
+
+export async function saveDeployHQRepoMapping(mapping: Record<string, string>): Promise<void> {
+  await chrome.storage.local.set({ [DEPLOYHQ_MAPPING_KEY]: mapping });
+}
+
 // === Install date & star prompt ===
 
 const INSTALL_DATE_KEY = 'pr_radar_install_date';
@@ -119,6 +146,8 @@ export async function clearAll(): Promise<void> {
     PR_CACHE_KEY,
     INSTALL_DATE_KEY,
     STAR_PROMPT_DISMISSED_KEY,
+    DEPLOYHQ_ACCOUNT_KEY,
+    DEPLOYHQ_MAPPING_KEY,
   ]);
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -117,4 +117,4 @@ export type Message =
   | { type: 'DELETE_BRANCH'; payload: { platform: Platform; repoFullName: string; branch: string } }
   | { type: 'TEST_DEPLOYHQ'; payload: { slug: string; email: string; apiKey: string } }
   | { type: 'GET_DEPLOYHQ_SERVERS'; payload: { repoFullName: string } }
-  | { type: 'CREATE_DEPLOYHQ_DEPLOYMENT'; payload: { repoFullName: string; serverIdentifier: string; serverType: 'server' | 'server_group' } };
+  | { type: 'CREATE_DEPLOYHQ_DEPLOYMENT'; payload: { repoFullName: string; serverIdentifier: string } };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -55,6 +55,34 @@ export interface PullRequest {
     status: 'success' | 'failure' | 'pending' | 'inactive';
     url?: string;
   };
+  deployhqProjectId?: string;
+  deployhqDeployment?: {
+    serverName: string;
+    url: string;
+  };
+}
+
+// === DeployHQ ===
+
+export interface DeployHQAccount {
+  slug: string;
+  email: string;
+  apiKey: string;
+  connected: boolean;
+  accountName?: string;
+}
+
+export interface DeployHQProject {
+  identifier: string;
+  name: string;
+  permalink: string;
+  repoUrl: string;
+}
+
+export interface DeployHQServer {
+  identifier: string;
+  name: string;
+  serverType: 'server' | 'server_group';
 }
 
 // === Watched repos ===
@@ -86,4 +114,7 @@ export type Message =
   | { type: 'GET_PRS'; payload: { tab: DashboardTab } }
   | { type: 'TEST_NOTIFICATION' }
   | { type: 'MERGE_PR'; payload: { platform: Platform; repoFullName: string; prNumber: number } }
-  | { type: 'DELETE_BRANCH'; payload: { platform: Platform; repoFullName: string; branch: string } };
+  | { type: 'DELETE_BRANCH'; payload: { platform: Platform; repoFullName: string; branch: string } }
+  | { type: 'TEST_DEPLOYHQ'; payload: { slug: string; email: string; apiKey: string } }
+  | { type: 'GET_DEPLOYHQ_SERVERS'; payload: { repoFullName: string } }
+  | { type: 'CREATE_DEPLOYHQ_DEPLOYMENT'; payload: { repoFullName: string; serverIdentifier: string; serverType: 'server' | 'server_group' } };


### PR DESCRIPTION
## Summary

- Adds an optional DeployHQ integration that lets users deploy directly from the PR dashboard
- Configured in Settings > Accounts > DeployHQ (account slug, email, API key)
- Automatically matches PR repos to DeployHQ projects during polling
- Deploy button with server/group selector on matched PRs, persistent deployment badge in badge row linking to DeployHQ dashboard

> **Note:** DeployHQ is the team behind PR Radar. This integration is entirely optional — the extension works fully without it. No extra API calls are made, and no UI changes appear unless the user explicitly connects their DeployHQ account.

## Files changed

| File | Change |
|------|--------|
| `src/shared/types.ts` | DeployHQ types, extended PullRequest and Message |
| `src/shared/storage.ts` | DeployHQ account and repo mapping storage |
| `src/shared/api/deployhq.ts` | **New** — DeployHQ API module |
| `manifest.json` | Added `*.deployhq.com` host permission |
| `src/background/service-worker.ts` | Message handlers + polling enrichment |
| `src/popup/pages/Settings.tsx` | DeployHQ row in Accounts section |
| `src/popup/components/PRItem.tsx` | Deploy button + deployment badge |
| `CLAUDE.md` / `README.md` | Documentation |
| `mockups/deployhq-integration.html` | UI mockups |

## Test plan

- [ ] Connect DeployHQ account in Settings (test with valid and invalid credentials)
- [ ] Verify "Connected" state persists after closing/reopening popup
- [ ] Disconnect and verify state clears
- [ ] Check Deploy button appears on PRs whose repos match a DeployHQ project
- [ ] Click Deploy, select server, confirm — verify deployment is queued
- [ ] Verify deployment badge appears in badge row and links to DeployHQ dashboard
- [ ] Verify extension works normally with DeployHQ disconnected (no regressions)
- [ ] Build passes for Chrome, Firefox, and Edge targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional DeployHQ integration: connect account in Settings, select servers/server-groups, deploy PRs from the dashboard, and show persistent clickable deployment badges.

* **Documentation**
  * README and architecture docs updated with setup steps, settings path, required fields, deploy workflow, and UI mockups.

* **Tests**
  * Added unit tests for repo URL parsing, project matching, server fetching, and connection behavior.

* **Chores**
  * Extension permissions expanded to include DeployHQ domains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->