### PR TITLE
Add support for self-hosted GitHub Enterprise and GitLab instances

### DIFF
--- a/docs/plans/self-hosted-instances.md
+++ b/docs/plans/self-hosted-instances.md
@@ -1,0 +1,161 @@
+# Self-hosted instance support
+
+Tracks GitHub issue #1: "Support self-hosted instances (GitHub Enterprise, GitLab self-managed, Bitbucket Server)".
+
+## Goal
+
+Allow users to connect accounts on self-hosted GitHub Enterprise, GitLab self-managed, and Bitbucket Data Center deployments — without bloating the UI for the 95% of users who stay on the public services.
+
+## Scope
+
+**In:**
+- GitLab self-managed (any version GitLab supports).
+- GitHub Enterprise Server (any actively-supported GHES version).
+- Bitbucket Data Center (Server is EOL February 2024, DC only).
+
+**Out:**
+- GitHub Enterprise *Cloud* — it's just GitHub.com with extra features; uses the same API hostnames. No change needed.
+- Per-instance feature gating (e.g., older GHES lacks some GraphQL fields). Detect at runtime and fall back where reasonable.
+
+## Platform asymmetry (important)
+
+The three platforms are **not** equivalent work:
+
+| Platform | API delta vs. cloud | Effort |
+|---|---|---|
+| GitLab self-managed | URL only — identical API surface | ~1 day |
+| GitHub Enterprise Server | URL + REST path (`/api/v3`) + GraphQL endpoint; some GraphQL fields missing on older versions, need REST fallback | ~2–3 days |
+| Bitbucket Data Center | **Different API entirely** (`/rest/api/1.0/...`), different auth (HTTP access tokens), different data shapes, different build-status API | ~5–10 days (effectively a new platform) |
+
+Recommendation: ship GitLab → GitHub Enterprise → Bitbucket DC as separate phases.  Reassess Bitbucket DC after the first two ship — if no real demand, defer indefinitely.
+
+## Data model
+
+Single optional field added to the `Account` shape:
+
+```ts
+interface Account {
+  id: string;
+  platform: 'github' | 'gitlab' | 'bitbucket';
+  // ... existing fields
+  instanceUrl?: string;  // new — absent ⇒ canonical default
+}
+```
+
+Canonical defaults (used when `instanceUrl` is absent):
+- `github` → `https://api.github.com`
+- `gitlab` → `https://gitlab.com`
+- `bitbucket` → `https://api.bitbucket.org`
+
+No migration required — existing accounts simply lack the field.
+
+## UI changes (minimal)
+
+One toggle, one input, one subtitle line.
+
+**Setup page:**
+- Above the token input, add a checkbox: **"Self-hosted instance?"**.
+- When toggled on, reveal one input: **"Instance URL"** with platform-specific placeholder (`https://gitlab.example.com` / `https://github.example.com` / `https://bitbucket.example.com`).
+- The token-link helper (pre-filled scopes URL) must point at the user's instance URL, not the canonical one.
+- Token validation call (e.g. `/user`) goes against the user's instance URL.
+
+**Settings → Accounts list:**
+- Show the instance URL as a small subtitle line only when it differs from the canonical default. Otherwise no change.
+
+**Repos / Dashboard / popup / notifications:**
+- No visual changes. URLs in PR titles, "open PR" actions, and badges all derive from the per-account instance URL.
+
+That's it. No new tabs, no platform-picker, no extra pages.
+
+## API client changes
+
+The pattern is identical across all three: take `instanceUrl` as a parameter, derive the base URL from it, fall back to the canonical default if absent.
+
+**`api/gitlab.ts`** (Phase 1 — easy):
+- Replace hardcoded `https://gitlab.com/api/v4` with `${instanceUrl ?? 'https://gitlab.com'}/api/v4`.
+- Everything else identical. Auth, scopes, endpoints, data shapes all match.
+
+**`api/github.ts`** (Phase 2 — medium):
+- REST: replace `https://api.github.com` with:
+  - Cloud: `https://api.github.com`
+  - GHES: `${instanceUrl}/api/v3` (note: instance URL excludes `/api/v3`)
+- GraphQL: replace `https://api.github.com/graphql` with:
+  - Cloud: `https://api.github.com/graphql`
+  - GHES: `${instanceUrl}/api/graphql`
+- Add a feature-detection or version-aware fallback for the `reviewThreads.isResolved` GraphQL field in case it's unavailable on older GHES. Fallback path: REST `/pulls/{n}/comments` with manual resolution-state inference (less accurate; flag in tooltip).
+
+**`api/bitbucket.ts`** (Phase 3 — heavy, defer):
+- Bitbucket DC has a separate REST API at `/rest/api/1.0/...` with different paths and shapes. Effectively a new client file (`api/bitbucket-dc.ts`) sharing only the `Account` type and result shapes.
+- Auth: HTTP access tokens via `Authorization: Bearer <token>` (not Atlassian Cloud's `email:token` Basic).
+- Pull request endpoints: `/projects/{projectKey}/repos/{slug}/pull-requests`.
+- Build status: separate API at `/rest/build-status/1.0/commits/{sha}`.
+- Reviewers, comments, merge: all different endpoints from Cloud.
+- Decision routed at the API client entry point based on `account.instanceUrl` presence.
+
+## Cross-cutting concerns
+
+1. **DeployHQ repo matching**: the integration matches PR `repoFullName` against DeployHQ project repository URLs. Self-hosted instances will have different host portions in those URLs — confirm matching still works (it should, since matching is on full URL, but verify with a test case).
+2. **Notification click-through**: notifications open the PR URL. Already host-aware (uses the PR's own URL field), but verify after refactor.
+3. **Repo discovery**: `/user/repos`, `/projects?membership=true`, `/repositories/{workspace}` calls all need the instance URL. Don't miss any.
+4. **Account identity uniqueness**: `accountId` must include instance host so two GitHub accounts on different instances don't collide. Suggest format `github:{instanceHost}:{username}`.
+5. **URL normalization**: trim trailing slashes, reject non-HTTPS in the input field unless the user explicitly opts into HTTP for local dev.
+6. **CSP / host_permissions**: `manifest.json` currently grants permission for canonical hosts only. Self-hosted requires `<all_urls>` or per-instance `optional_host_permissions` requested at connect time. Latter is more privacy-respectful; do that.
+
+## Tasks (ordered, each verifiable)
+
+### Phase 1 — GitLab self-managed (~1 day)
+
+1. **Account model**: add optional `instanceUrl` field; helper `accountBaseUrl(account)` returning canonical fallback. Verify with unit tests.
+2. **Setup UI toggle**: checkbox + URL input + placeholder; only shown when toggled. Verify: form state correctly stores `instanceUrl` only when toggled.
+3. **API client refactor** in `api/gitlab.ts`: parameterize base URL. Replace all hardcoded `gitlab.com` references. Verify: existing gitlab.com flow unaffected (regression test).
+4. **Connect-time host permission request**: when `instanceUrl` is set, call `chrome.permissions.request({ origins: [`${url}/*`] })`. Block save until granted. Verify: connecting a self-hosted account triggers the permission prompt; canonical accounts don't.
+5. **Token-link helper**: pre-filled scopes URL uses instance URL. Verify visually.
+6. **Account list subtitle**: show instance URL when it differs from default. Verify.
+7. **End-to-end manual test**: connect to a real self-managed GitLab instance (DeployHQ likely has internal access; otherwise spin up GitLab Docker). Confirm PR list, CI, discussions, deployments, merge all work.
+
+### Phase 2 — GitHub Enterprise Server (~2–3 days)
+
+8. **API client refactor** in `api/github.ts`: parameterize REST base (`/api/v3` for GHES, `/api/v3`-less for Cloud) and GraphQL endpoint. Verify: cloud flow unaffected.
+9. **GraphQL field fallback**: detect missing `reviewThreads.isResolved` on older GHES (introspection or 422 response handling) and fall back to REST comments path. Surface "approximate count" in the tooltip when fallback is active.
+10. **Setup UI**: same toggle reused; placeholder swapped per platform.
+11. **Connect-time permission request**: same pattern as Phase 1.
+12. **Manual test**: against a real GHES instance (find via DeployHQ, GHES trial, or community contact from Reddit/issue thread).
+
+### Phase 3 — Bitbucket Data Center (~5–10 days, defer)
+
+13. **Spike** (1 day): set up a Bitbucket DC trial, document API differences, identify minimum viable feature set (PR list, build status, comments, reviewers, merge).
+14. **New client file** `api/bitbucket-dc.ts`: implement minimum viable feature set against `/rest/api/1.0/...`.
+15. **Routing layer**: at the platform client entry point, choose between Cloud and DC clients based on `instanceUrl` presence.
+16. **Setup UI**: same toggle reused; placeholder swapped.
+17. **Auth**: HTTP access token bearer flow (different from Cloud's Basic).
+18. **Manual test**: against the spike instance.
+19. **Decision gate before starting Phase 3**: confirm there's measurable demand (issue thumbs-ups, support requests). If none, indefinitely defer and close the issue with a "low demand, can reopen" note.
+
+## Verification
+
+- Unit: `accountBaseUrl()` returns canonical defaults when absent, instance URLs when present.
+- Integration (per phase): end-to-end against a real self-hosted instance for that platform.
+- Regression: existing canonical-host users see no behavior change; manifest permission changes don't break re-loads.
+- UI: form is invisible to canonical users (toggle defaults off).
+
+## Risks / open questions
+
+1. **Permission prompt UX**: Chrome's `permissions.request()` must be called from a user gesture. The "Save account" click counts. Confirm flow doesn't break in popup context.
+2. **Older GHES versions**: not all GraphQL fields exist. Fallback path to REST works but is less accurate. Acceptable; document in tooltip.
+3. **Bitbucket DC effort vs. demand**: 5–10 days is significant. Worth gating on real signal.
+4. **Test access**: GHES and Bitbucket DC are gated trials. Coordinate with DeployHQ infra or via community testers (e.g., the Reddit commenter from the gitlab post).
+5. **Manifest changes**: moving from named hosts to `optional_host_permissions` may require store re-review. Verify with Chrome Web Store before submitting.
+
+## Effort summary
+
+| Phase | Effort | Ship-ready? |
+|---|---|---|
+| 1 — GitLab self-managed | ~1 day | Yes, can ship standalone |
+| 2 — GitHub Enterprise | ~2–3 days | Yes, can ship standalone |
+| 3 — Bitbucket DC | ~5–10 days | Defer, gate on demand |
+
+Phase 1 alone is a strong reply to the open issue and the Reddit comment. Phase 2 is a natural follow-up once the toggle scaffolding exists. Phase 3 only if demand materializes.
+
+## Origin
+
+GitHub issue #1, opened 2 weeks ago. Re-prompted on r/webdev Showoff Saturday post (2026-05-02) by `ModernOldschool`.

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,12 @@
     "https://id.atlassian.com/*",
     "https://*.deployhq.com/*"
   ],
+  "{{chrome}}.optional_host_permissions": [
+    "https://*/*"
+  ],
+  "{{firefox}}.optional_permissions": [
+    "https://*/*"
+  ],
   "{{chrome}}.background": {
     "service_worker": "src/background/service-worker.ts",
     "type": "module"

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -62,9 +62,9 @@ chrome.runtime.onMessage.addListener((message: Message, _sender, sendResponse) =
       }
       let result: { success: boolean; message: string };
       if (platform === 'github') {
-        result = await github.mergePullRequest(account.token, repoFullName, prNumber);
+        result = await github.mergePullRequest(account.token, repoFullName, prNumber, account.instanceUrl);
       } else if (platform === 'gitlab') {
-        result = await gitlab.mergeMergeRequest(account.token, repoFullName, prNumber);
+        result = await gitlab.mergeMergeRequest(account.token, repoFullName, prNumber, account.instanceUrl);
       } else {
         result = await bitbucket.mergePullRequest(account.token, repoFullName, prNumber);
       }
@@ -82,7 +82,7 @@ chrome.runtime.onMessage.addListener((message: Message, _sender, sendResponse) =
         return;
       }
       if (platform === 'github') {
-        const result = await github.deleteBranch(account.token, repoFullName, branch);
+        const result = await github.deleteBranch(account.token, repoFullName, branch, account.instanceUrl);
         sendResponse(result);
       } else {
         sendResponse({ success: false, message: 'Not supported for this platform' });
@@ -250,10 +250,10 @@ async function pollPRs() {
       for (const repo of repos) {
         try {
           if (account.platform === 'github') {
-            const prs = await github.fetchPullRequests(account.token, repo.fullName, account.username);
+            const prs = await github.fetchPullRequests(account.token, repo.fullName, account.username, account.instanceUrl);
             allPRs.push(...prs);
           } else if (account.platform === 'gitlab') {
-            const prs = await gitlab.fetchMergeRequests(account.token, repo.fullName, account.username);
+            const prs = await gitlab.fetchMergeRequests(account.token, repo.fullName, account.username, account.instanceUrl);
             allPRs.push(...prs);
           } else if (account.platform === 'bitbucket') {
             const prs = await bitbucket.fetchPullRequests(account.token, repo.fullName, account.username);
@@ -342,9 +342,9 @@ async function pollPRs() {
         try {
           let merged = false;
           if (pr.platform === 'github') {
-            merged = await github.checkIfMerged(account.token, pr.repoFullName, pr.number);
+            merged = await github.checkIfMerged(account.token, pr.repoFullName, pr.number, account.instanceUrl);
           } else if (pr.platform === 'gitlab') {
-            merged = await gitlab.checkIfMerged(account.token, pr.repoFullName, pr.number);
+            merged = await gitlab.checkIfMerged(account.token, pr.repoFullName, pr.number, account.instanceUrl);
           } else if (pr.platform === 'bitbucket') {
             merged = await bitbucket.checkIfMerged(account.token, pr.repoFullName, pr.number);
           }
@@ -369,7 +369,7 @@ async function pollPRs() {
         const account = accounts.find((a) => a.platform === pr.platform);
         if (pr.platform === 'github' && pr.headSha && account) {
           try {
-            const ciResult = await github.refreshCIStatus(account.token, pr.repoFullName, pr.headSha);
+            const ciResult = await github.refreshCIStatus(account.token, pr.repoFullName, pr.headSha, account.instanceUrl);
             allPRs.push({ ...pr, ciStatus: ciResult.status, ciFailedChecks: ciResult.failedChecks.length > 0 ? ciResult.failedChecks : undefined });
           } catch {
             allPRs.push(pr); // keep with old status

--- a/src/popup/pages/Repos.tsx
+++ b/src/popup/pages/Repos.tsx
@@ -23,7 +23,7 @@ export default function Repos() {
       for (const account of accounts) {
         try {
           if (account.platform === 'github') {
-            const ghRepos = await github.getUserRepos(account.token);
+            const ghRepos = await github.getUserRepos(account.token, account.instanceUrl);
             for (const r of ghRepos) {
               const key = `github:${r.full_name}`;
               const saved = watchedMap.get(key);
@@ -35,7 +35,7 @@ export default function Repos() {
               });
             }
           } else if (account.platform === 'gitlab') {
-            const glRepos = await gitlab.getUserProjects(account.token);
+            const glRepos = await gitlab.getUserProjects(account.token, account.instanceUrl);
             for (const r of glRepos) {
               const key = `gitlab:${r.path_with_namespace}`;
               const saved = watchedMap.get(key);

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -3,6 +3,7 @@ import type { AppView, Platform, DeployHQAccount } from '@/shared/types';
 import { PLATFORM_LABELS, SOUND_OPTIONS } from '@/shared/constants';
 import { getSettings, saveSettings, getAccounts, removeAccount, getDeployHQAccount, removeDeployHQAccount, type Settings as SettingsType, type ThemeMode } from '@/shared/storage';
 import { STORE_URL, GITHUB_REPO_URL, GITHUB_ISSUES_URL } from '@/shared/constants';
+import { getDisplayHost } from '@/shared/instanceUrl';
 
 interface SettingsProps {
   onNavigate: (view: AppView) => void;
@@ -12,7 +13,7 @@ interface SettingsProps {
 
 export default function Settings({ onNavigate, theme, onThemeChange }: SettingsProps) {
   const [settings, setSettings] = useState<SettingsType | null>(null);
-  const [connectedPlatforms, setConnectedPlatforms] = useState<{ platform: Platform; username: string }[]>([]);
+  const [connectedPlatforms, setConnectedPlatforms] = useState<{ platform: Platform; username: string; instanceHost: string | null }[]>([]);
 
   // DeployHQ state
   const [dhqAccount, setDhqAccount] = useState<DeployHQAccount | null>(null);
@@ -27,7 +28,11 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
     async function load() {
       const [s, accounts, dhq] = await Promise.all([getSettings(), getAccounts(), getDeployHQAccount()]);
       setSettings(s);
-      setConnectedPlatforms(accounts.map((a) => ({ platform: a.platform, username: a.username })));
+      setConnectedPlatforms(accounts.map((a) => ({
+        platform: a.platform,
+        username: a.username,
+        instanceHost: getDisplayHost(a),
+      })));
       if (dhq) {
         setDhqAccount(dhq);
         setDhqSlug(dhq.slug);
@@ -241,11 +246,11 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
 
       {/* Accounts */}
       <Section title="Accounts">
-        {connectedPlatforms.map(({ platform, username }) => (
+        {connectedPlatforms.map(({ platform, username, instanceHost }) => (
           <SettingRow
             key={platform}
             label={PLATFORM_LABELS[platform]}
-            description={`@${username}`}
+            description={instanceHost ? `@${username} · ${instanceHost}` : `@${username}`}
           >
             <button
               onClick={() => handleDisconnect(platform)}

--- a/src/popup/pages/Setup.tsx
+++ b/src/popup/pages/Setup.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type { Platform, PlatformAccount } from '@/shared/types';
 import { PLATFORM_LABELS } from '@/shared/constants';
 import { getAccounts, saveAccount } from '@/shared/storage';
+import { normalizeInstanceUrl, requestInstanceHostPermission } from '@/shared/instanceUrl';
 import PlatformIcon from '../components/PlatformIcon';
 import * as github from '@/shared/api/github';
 import * as gitlab from '@/shared/api/gitlab';
@@ -24,6 +25,12 @@ interface PlatformConfig {
   comingSoon: boolean;
   scopes: ScopeInfo[];
   note?: string;
+  /** Whether the self-hosted instance toggle is offered for this platform. */
+  supportsSelfHosted: boolean;
+  /** Build a token-creation URL for the user's instance (canonical or self-hosted). */
+  buildTokenUrl?: (instanceUrl: string) => string;
+  /** Placeholder shown in the Instance URL input. */
+  instancePlaceholder?: string;
 }
 
 const PLATFORMS: PlatformConfig[] = [
@@ -38,6 +45,10 @@ const PLATFORMS: PlatformConfig[] = [
       { name: 'read:org', reason: 'List organization repositories' },
     ],
     note: 'If your org uses SSO, authorize the token for that org after creating it.',
+    supportsSelfHosted: true,
+    buildTokenUrl: (instanceUrl) =>
+      `${instanceUrl.replace(/\/+$/, '')}/settings/tokens/new?scopes=repo,read:org&description=PR%20Radar`,
+    instancePlaceholder: 'https://github.example.com',
   },
   {
     platform: 'gitlab',
@@ -50,6 +61,10 @@ const PLATFORMS: PlatformConfig[] = [
       { name: 'read_user', reason: 'Identify your account' },
     ],
     note: 'The api scope is needed to merge MRs. read_api is sufficient if you don\'t need merge.',
+    supportsSelfHosted: true,
+    buildTokenUrl: (instanceUrl) =>
+      `${instanceUrl.replace(/\/+$/, '')}/-/user_settings/personal_access_tokens?name=PR+Radar&scopes=api,read_user`,
+    instancePlaceholder: 'https://gitlab.example.com',
   },
   {
     platform: 'bitbucket',
@@ -64,6 +79,7 @@ const PLATFORMS: PlatformConfig[] = [
       { name: 'read:pullrequest:bitbucket', reason: 'View pull requests and CI' },
       { name: 'write:pullrequest:bitbucket', reason: 'Merge pull requests' },
     ],
+    supportsSelfHosted: false,
   },
 ];
 
@@ -77,6 +93,8 @@ export default function Setup({ onComplete }: SetupProps) {
   const [connectingPlatform, setConnectingPlatform] = useState<Platform | null>(null);
   const [token, setToken] = useState('');
   const [bbEmail, setBbEmail] = useState('');
+  const [selfHosted, setSelfHosted] = useState(false);
+  const [instanceUrl, setInstanceUrl] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [connectedPlatforms, setConnectedPlatforms] = useState<Map<Platform, string>>(new Map());
@@ -87,21 +105,49 @@ export default function Setup({ onComplete }: SetupProps) {
     });
   }, []);
 
+  function resetForm() {
+    setToken('');
+    setBbEmail('');
+    setSelfHosted(false);
+    setInstanceUrl('');
+    setError('');
+  }
+
   async function handleConnect(platform: Platform) {
     if (!token.trim()) return;
+
+    let normalizedInstance: string | undefined;
+    if (selfHosted) {
+      const normalized = normalizeInstanceUrl(instanceUrl);
+      if (!normalized) {
+        setError('Enter a valid HTTPS instance URL (e.g. https://gitlab.example.com).');
+        return;
+      }
+      normalizedInstance = normalized;
+    }
 
     setLoading(true);
     setError('');
 
     try {
+      // Request runtime host permission for self-hosted instances before any API call.
+      if (normalizedInstance) {
+        const granted = await requestInstanceHostPermission(normalizedInstance);
+        if (!granted) {
+          setError('Permission to access this instance was denied. Connection cancelled.');
+          setLoading(false);
+          return;
+        }
+      }
+
       let account: PlatformAccount;
 
       if (platform === 'github') {
-        const user = await github.getAuthenticatedUser(token.trim());
-        account = { platform, token: token.trim(), username: user.login, avatarUrl: user.avatar_url };
+        const user = await github.getAuthenticatedUser(token.trim(), normalizedInstance);
+        account = { platform, token: token.trim(), username: user.login, avatarUrl: user.avatar_url, instanceUrl: normalizedInstance };
       } else if (platform === 'gitlab') {
-        const user = await gitlab.getAuthenticatedUser(token.trim());
-        account = { platform, token: token.trim(), username: user.username, avatarUrl: user.avatar_url };
+        const user = await gitlab.getAuthenticatedUser(token.trim(), normalizedInstance);
+        account = { platform, token: token.trim(), username: user.username, avatarUrl: user.avatar_url, instanceUrl: normalizedInstance };
       } else {
         if (!bbEmail.trim()) {
           setError('Email is required for Bitbucket.');
@@ -137,6 +183,10 @@ export default function Setup({ onComplete }: SetupProps) {
           const isExpanded = connectingPlatform === cfg.platform;
           const connectedUser = connectedPlatforms.get(cfg.platform);
           const isConnected = !!connectedUser;
+          const normalizedInstance = selfHosted ? normalizeInstanceUrl(instanceUrl) : null;
+          const helpUrl = isExpanded && cfg.supportsSelfHosted && cfg.buildTokenUrl && normalizedInstance
+            ? cfg.buildTokenUrl(normalizedInstance)
+            : cfg.helpUrl;
 
           return (
             <div
@@ -154,9 +204,7 @@ export default function Setup({ onComplete }: SetupProps) {
                 onClick={() => {
                   if (cfg.comingSoon || isConnected) return;
                   setConnectingPlatform(isExpanded ? null : cfg.platform);
-                  setToken('');
-                  setBbEmail('');
-                  setError('');
+                  resetForm();
                 }}
                 disabled={cfg.comingSoon || isConnected}
               >
@@ -192,6 +240,34 @@ export default function Setup({ onComplete }: SetupProps) {
 
               {isExpanded && !cfg.comingSoon && (
                 <div className="px-4 pb-4 space-y-2">
+                  {cfg.supportsSelfHosted && (
+                    <label className="flex items-center gap-2 cursor-pointer select-none py-1">
+                      <input
+                        type="checkbox"
+                        checked={selfHosted}
+                        onChange={(e) => {
+                          setSelfHosted(e.target.checked);
+                          setError('');
+                          if (!e.target.checked) setInstanceUrl('');
+                        }}
+                        className="rounded border-gray-300 dark:border-gray-700 text-radar-600 focus:ring-radar-500"
+                      />
+                      <span className="text-[12px] text-gray-700 dark:text-gray-300">
+                        Self-hosted instance
+                      </span>
+                    </label>
+                  )}
+                  {cfg.supportsSelfHosted && selfHosted && (
+                    <input
+                      type="url"
+                      value={instanceUrl}
+                      onChange={(e) => setInstanceUrl(e.target.value)}
+                      placeholder={cfg.instancePlaceholder ?? 'https://your-instance.example.com'}
+                      aria-label="Instance URL"
+                      className="w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-600 outline-none focus:border-radar-500"
+                      autoFocus
+                    />
+                  )}
                   {cfg.platform === 'bitbucket' && (
                     <input
                       type="email"
@@ -210,10 +286,10 @@ export default function Setup({ onComplete }: SetupProps) {
                     placeholder={cfg.placeholder}
                     aria-label={`${PLATFORM_LABELS[cfg.platform]} personal access token`}
                     className="w-full bg-gray-50 dark:bg-gray-900 border border-gray-300 dark:border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-900 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-600 outline-none focus:border-radar-500"
-                    autoFocus={cfg.platform !== 'bitbucket'}
+                    autoFocus={cfg.platform !== 'bitbucket' && !(cfg.supportsSelfHosted && selfHosted)}
                   />
                   <a
-                    href={cfg.helpUrl}
+                    href={helpUrl}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="text-[11px] text-radar-400 hover:underline block"
@@ -238,7 +314,7 @@ export default function Setup({ onComplete }: SetupProps) {
                   {error && <p className="text-[11px] text-red-400" role="alert">{error}</p>}
                   <button
                     onClick={() => handleConnect(cfg.platform)}
-                    disabled={loading || !token.trim() || (cfg.platform === 'bitbucket' && !bbEmail.trim())}
+                    disabled={loading || !token.trim() || (cfg.platform === 'bitbucket' && !bbEmail.trim()) || (selfHosted && !instanceUrl.trim())}
                     className="w-full py-2 bg-radar-600 hover:bg-radar-700 disabled:opacity-50 text-white text-sm font-medium rounded-lg transition-colors"
                   >
                     {loading ? 'Verifying...' : 'Connect'}

--- a/src/popup/pages/Setup.tsx
+++ b/src/popup/pages/Setup.tsx
@@ -118,9 +118,18 @@ export default function Setup({ onComplete }: SetupProps) {
 
     let normalizedInstance: string | undefined;
     if (selfHosted) {
-      const normalized = normalizeInstanceUrl(instanceUrl);
-      if (!normalized) {
+      const trimmed = instanceUrl.trim();
+      if (!trimmed) {
         setError('Enter a valid HTTPS instance URL (e.g. https://gitlab.example.com).');
+        return;
+      }
+      const normalized = normalizeInstanceUrl(trimmed, platform);
+      if (!normalized) {
+        // Distinguish "this is just the canonical" from "this is invalid"
+        const isCanonical = normalizeInstanceUrl(trimmed) !== null;
+        setError(isCanonical
+          ? `That's the public ${PLATFORM_LABELS[platform]} URL — untoggle "Self-hosted instance" to use the public service.`
+          : 'Enter a valid HTTPS instance URL (e.g. https://gitlab.example.com).');
         return;
       }
       normalizedInstance = normalized;

--- a/src/shared/api/github.test.ts
+++ b/src/shared/api/github.test.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   checkHasReviewed,
   deriveReviewStatus,
+  getAuthenticatedUser,
   getNextPagePath,
   getUserRepos,
   mapWithConcurrencyLimit,
+  mergePullRequest,
   type GHReview,
 } from './github';
 
@@ -120,6 +122,18 @@ describe('getNextPagePath', () => {
   it('returns null when there is no next page', () => {
     expect(getNextPagePath('<https://api.github.com/resource?page=4>; rel="last"')).toBeNull();
   });
+
+  it('strips the /api/v3 prefix on GitHub Enterprise Server links', () => {
+    const linkHeader = '<https://github.example.com/api/v3/user/repos?page=2>; rel="next"';
+    expect(getNextPagePath(linkHeader, 'https://github.example.com/api/v3'))
+      .toBe('/user/repos?page=2');
+  });
+
+  it('returns null when the link origin differs from the configured base URL', () => {
+    // GHES base configured but the link points at api.github.com (mismatched origin)
+    const linkHeader = '<https://api.github.com/resource?page=2>; rel="next"';
+    expect(getNextPagePath(linkHeader, 'https://github.example.com/api/v3')).toBeNull();
+  });
 });
 
 describe('mapWithConcurrencyLimit', () => {
@@ -190,3 +204,68 @@ function jsonResponse(body: unknown, linkHeader?: string): Response {
     },
   } as unknown as Response;
 }
+
+describe('GitHub Enterprise Server URL routing', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('getAuthenticatedUser hits api.github.com when no instanceUrl is provided', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ login: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe('https://api.github.com/user');
+  });
+
+  it('getAuthenticatedUser routes to {instanceUrl}/api/v3 for GHES', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ login: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token', 'https://github.example.com');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://github.example.com/api/v3/user');
+  });
+
+  it('getAuthenticatedUser strips trailing slashes from instanceUrl', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ login: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token', 'https://github.example.com/');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://github.example.com/api/v3/user');
+  });
+
+  it('getUserRepos routes pagination to the GHES base', async () => {
+    const fetchMock = vi.mocked(globalThis.fetch);
+
+    // Personal repos page 1 with link to page 2 on the GHES host. Real GitHub
+    // URL-encodes commas in affiliation, so we mirror that here (literal commas
+    // inside the URL would confuse the comma-delimited Link-header parser).
+    fetchMock.mockResolvedValueOnce(jsonResponse(
+      [{ full_name: 'acme/alpha' }],
+      '<https://github.example.com/api/v3/user/repos?sort=pushed&per_page=100&affiliation=owner%2Ccollaborator%2Corganization_member&page=2>; rel="next"',
+    ));
+    fetchMock.mockResolvedValueOnce(jsonResponse([{ full_name: 'acme/beta' }]));
+    // Orgs list (empty so we don't have to mock org repo fetches)
+    fetchMock.mockResolvedValueOnce(jsonResponse([]));
+
+    const repos = await getUserRepos('token', 'https://github.example.com');
+
+    expect(repos).toEqual([
+      { full_name: 'acme/alpha' },
+      { full_name: 'acme/beta' },
+    ]);
+    // Every call should target the GHES /api/v3 base
+    for (const call of fetchMock.mock.calls) {
+      expect(call[0]).toMatch(/^https:\/\/github\.example\.com\/api\/v3\//);
+    }
+  });
+
+  it('mergePullRequest routes to the GHES instance', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({ ok: true } as Response);
+    await mergePullRequest('token', 'acme/alpha', 7, 'https://github.example.com');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://github.example.com/api/v3/repos/acme/alpha/pulls/7/merge');
+  });
+});

--- a/src/shared/api/github.test.ts
+++ b/src/shared/api/github.test.ts
@@ -268,4 +268,18 @@ describe('GitHub Enterprise Server URL routing', () => {
     expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
       .toBe('https://github.example.com/api/v3/repos/acme/alpha/pulls/7/merge');
   });
+
+  it('routes to api.github.com when instanceUrl is the canonical github.com', async () => {
+    // Defensive: legacy or accidentally-persisted instanceUrl='https://github.com'
+    // must not become 'https://github.com/api/v3' (which is not the cloud REST API).
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ login: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token', 'https://github.com');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe('https://api.github.com/user');
+  });
+
+  it('handles trailing slash on canonical github.com', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(jsonResponse({ login: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token', 'https://github.com/');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe('https://api.github.com/user');
+  });
 });

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -1,9 +1,25 @@
 import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo } from '../types';
 
-const BASE_URL = 'https://api.github.com';
+const CANONICAL_BASE_URL = 'https://api.github.com';
+const CANONICAL_GRAPHQL_URL = 'https://api.github.com/graphql';
 const HYDRATE_CONCURRENCY = 5;
 const ORG_FETCH_CONCURRENCY = 4;
 const MAX_PAGINATED_PAGES = 20;
+
+/**
+ * Resolve REST API base from a user-facing instance URL. GitHub Enterprise Server
+ * mounts the API at `/api/v3`; canonical github.com uses `api.github.com`.
+ */
+function resolveBaseUrl(instanceUrl?: string): string {
+  if (!instanceUrl) return CANONICAL_BASE_URL;
+  return `${instanceUrl.replace(/\/+$/, '')}/api/v3`;
+}
+
+/** Resolve GraphQL endpoint URL from a user-facing instance URL. */
+function resolveGraphQLUrl(instanceUrl?: string): string {
+  if (!instanceUrl) return CANONICAL_GRAPHQL_URL;
+  return `${instanceUrl.replace(/\/+$/, '')}/api/graphql`;
+}
 
 let lastRateLimit: RateLimitInfo | null = null;
 
@@ -35,8 +51,8 @@ export class GitHubAPIError extends Error {
   }
 }
 
-async function ghFetchRaw(path: string, token: string): Promise<Response> {
-  const res = await fetch(`${BASE_URL}${path}`, {
+async function ghFetchRaw(path: string, token: string, baseUrl: string): Promise<Response> {
+  const res = await fetch(`${baseUrl}${path}`, {
     headers: {
       Authorization: `Bearer ${token}`,
       Accept: 'application/vnd.github+json',
@@ -50,12 +66,12 @@ async function ghFetchRaw(path: string, token: string): Promise<Response> {
   return res;
 }
 
-async function ghFetch<T>(path: string, token: string): Promise<T> {
-  const res = await ghFetchRaw(path, token);
+async function ghFetch<T>(path: string, token: string, baseUrl: string): Promise<T> {
+  const res = await ghFetchRaw(path, token, baseUrl);
   return res.json();
 }
 
-export function getNextPagePath(linkHeader: string | null): string | null {
+export function getNextPagePath(linkHeader: string | null, baseUrl: string = CANONICAL_BASE_URL): string | null {
   if (!linkHeader) return null;
 
   for (const part of linkHeader.split(',')) {
@@ -63,14 +79,22 @@ export function getNextPagePath(linkHeader: string | null): string | null {
     if (!match || match[2] !== 'next') continue;
 
     const url = new URL(match[1]);
-    if (url.origin !== BASE_URL) return null;
-    return `${url.pathname}${url.search}`;
+    const expectedOrigin = new URL(baseUrl).origin;
+    if (url.origin !== expectedOrigin) return null;
+
+    // Strip the API base path (e.g. /api/v3 on GHES) so we get a path that's
+    // relative to the same baseUrl we'll prepend on the next call.
+    const basePath = new URL(baseUrl).pathname.replace(/\/+$/, '');
+    const pagePath = basePath && url.pathname.startsWith(basePath)
+      ? url.pathname.slice(basePath.length)
+      : url.pathname;
+    return `${pagePath}${url.search}`;
   }
 
   return null;
 }
 
-async function ghPaginate<T>(path: string, token: string, maxPages = MAX_PAGINATED_PAGES): Promise<T[]> {
+async function ghPaginate<T>(path: string, token: string, baseUrl: string, maxPages = MAX_PAGINATED_PAGES): Promise<T[]> {
   const results: T[] = [];
   const seenPaths = new Set<string>();
   let nextPath: string | null = path;
@@ -78,10 +102,10 @@ async function ghPaginate<T>(path: string, token: string, maxPages = MAX_PAGINAT
 
   while (nextPath && pageCount < maxPages && !seenPaths.has(nextPath)) {
     seenPaths.add(nextPath);
-    const res = await ghFetchRaw(nextPath, token);
+    const res = await ghFetchRaw(nextPath, token, baseUrl);
     const page = await res.json() as T[];
     results.push(...page);
-    nextPath = getNextPagePath(res.headers.get('link'));
+    nextPath = getNextPagePath(res.headers.get('link'), baseUrl);
     pageCount += 1;
   }
 
@@ -144,21 +168,23 @@ export interface GHReview {
   commit_id: string;
 }
 
-export async function getAuthenticatedUser(token: string): Promise<{ login: string; avatar_url: string }> {
-  return ghFetch('/user', token);
+export async function getAuthenticatedUser(token: string, instanceUrl?: string): Promise<{ login: string; avatar_url: string }> {
+  return ghFetch('/user', token, resolveBaseUrl(instanceUrl));
 }
 
-export async function getUserRepos(token: string): Promise<{ full_name: string }[]> {
+export async function getUserRepos(token: string, instanceUrl?: string): Promise<{ full_name: string }[]> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
   // Fetch personal repos
   const userRepos = await ghPaginate<{ full_name: string }>(
     '/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member',
     token,
+    baseUrl,
   );
 
   // Fetch orgs the user belongs to, then fetch repos from each org
   // Use type=member to include private repos the user has access to
   try {
-    const orgs = await ghFetch<{ login: string }[]>('/user/orgs?per_page=100', token);
+    const orgs = await ghFetch<{ login: string }[]>('/user/orgs?per_page=100', token, baseUrl);
     const orgRepoLists = await mapWithConcurrencyLimit(
       orgs,
       ORG_FETCH_CONCURRENCY,
@@ -167,10 +193,12 @@ export async function getUserRepos(token: string): Promise<{ full_name: string }
           ghPaginate<{ full_name: string }>(
             `/orgs/${org.login}/repos?sort=pushed&per_page=100&type=member`,
             token,
+            baseUrl,
           ).catch(() => [] as { full_name: string }[]),
           ghPaginate<{ full_name: string }>(
             `/orgs/${org.login}/repos?sort=pushed&per_page=100&type=all`,
             token,
+            baseUrl,
           ).catch(() => [] as { full_name: string }[]),
         ]);
 
@@ -200,9 +228,11 @@ export async function mergePullRequest(
   token: string,
   repoFullName: string,
   prNumber: number,
+  instanceUrl?: string,
 ): Promise<{ success: boolean; message: string }> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
   try {
-    const res = await fetch(`${BASE_URL}/repos/${repoFullName}/pulls/${prNumber}/merge`, {
+    const res = await fetch(`${baseUrl}/repos/${repoFullName}/pulls/${prNumber}/merge`, {
       method: 'PUT',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -225,9 +255,11 @@ export async function deleteBranch(
   token: string,
   repoFullName: string,
   branch: string,
+  instanceUrl?: string,
 ): Promise<{ success: boolean; message: string }> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
   try {
-    const res = await fetch(`${BASE_URL}/repos/${repoFullName}/git/refs/heads/${branch}`, {
+    const res = await fetch(`${baseUrl}/repos/${repoFullName}/git/refs/heads/${branch}`, {
       method: 'DELETE',
       headers: {
         Authorization: `Bearer ${token}`,
@@ -245,33 +277,39 @@ export async function deleteBranch(
   }
 }
 
-export async function checkIfMerged(token: string, repoFullName: string, prNumber: number): Promise<boolean> {
+export async function checkIfMerged(token: string, repoFullName: string, prNumber: number, instanceUrl?: string): Promise<boolean> {
   try {
-    const pr = await ghFetch<{ merged: boolean }>(`/repos/${repoFullName}/pulls/${prNumber}`, token);
+    const baseUrl = resolveBaseUrl(instanceUrl);
+    const pr = await ghFetch<{ merged: boolean }>(`/repos/${repoFullName}/pulls/${prNumber}`, token, baseUrl);
     return pr.merged;
   } catch {
     return false;
   }
 }
 
-export async function refreshCIStatus(token: string, repoFullName: string, headSha: string): Promise<{ status: CIStatus; failedChecks: string[] }> {
-  return fetchCIStatus(token, repoFullName, headSha);
+export async function refreshCIStatus(token: string, repoFullName: string, headSha: string, instanceUrl?: string): Promise<{ status: CIStatus; failedChecks: string[] }> {
+  return fetchCIStatus(token, repoFullName, headSha, resolveBaseUrl(instanceUrl));
 }
 
 export async function fetchPullRequests(
   token: string,
   repoFullName: string,
   username: string,
+  instanceUrl?: string,
 ): Promise<PullRequest[]> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
+  const graphqlUrl = resolveGraphQLUrl(instanceUrl);
+
   const prs = await ghPaginate<GHPullRequest>(
     `/repos/${repoFullName}/pulls?state=open&per_page=100`,
     token,
+    baseUrl,
   );
 
   const results = await mapWithConcurrencyLimit(
     prs,
     HYDRATE_CONCURRENCY,
-    (pr) => hydratePR(token, repoFullName, pr, username),
+    (pr) => hydratePR(token, repoFullName, pr, username, baseUrl, graphqlUrl),
   );
 
   return results;
@@ -282,13 +320,15 @@ async function hydratePR(
   repoFullName: string,
   pr: GHPullRequest,
   username: string,
+  baseUrl: string,
+  graphqlUrl: string,
 ): Promise<PullRequest> {
   // Fetch CI status, reviews, unresolved threads, and deployments in parallel
   const [ciResult, reviews, graphqlDetails, deployment] = await Promise.all([
-    fetchCIStatus(token, repoFullName, pr.head.sha),
-    ghFetch<GHReview[]>(`/repos/${repoFullName}/pulls/${pr.number}/reviews`, token),
-    fetchGraphQLDetails(token, repoFullName, pr.number),
-    fetchDeployment(token, repoFullName, pr.head.sha),
+    fetchCIStatus(token, repoFullName, pr.head.sha, baseUrl),
+    ghFetch<GHReview[]>(`/repos/${repoFullName}/pulls/${pr.number}/reviews`, token, baseUrl),
+    fetchGraphQLDetails(token, repoFullName, pr.number, graphqlUrl),
+    fetchDeployment(token, repoFullName, pr.head.sha, baseUrl),
   ]);
 
   const reviewStatus = deriveReviewStatus(reviews, pr.head.sha);
@@ -348,17 +388,19 @@ interface CIResult {
   durationMs?: number;
 }
 
-async function fetchCIStatus(token: string, repoFullName: string, headSha: string): Promise<CIResult> {
+async function fetchCIStatus(token: string, repoFullName: string, headSha: string, baseUrl: string): Promise<CIResult> {
   try {
     // Use the combined status endpoint for the PR's head commit
     const [combinedStatus, checkRuns] = await Promise.all([
       ghFetch<{ state: string }>(
         `/repos/${repoFullName}/commits/${headSha}/status`,
         token,
+        baseUrl,
       ),
       ghFetch<{ total_count: number; check_runs: { name: string; status: string; conclusion: string | null; started_at: string | null; completed_at: string | null }[] }>(
         `/repos/${repoFullName}/commits/${headSha}/check-runs`,
         token,
+        baseUrl,
       ),
     ]);
 
@@ -460,12 +502,14 @@ async function fetchDeployment(
   token: string,
   repoFullName: string,
   headSha: string,
+  baseUrl: string,
 ): Promise<PullRequest['deployment']> {
   try {
     // Get deployments for this specific SHA
     const deployments = await ghFetch<{ id: number; environment: string }[]>(
       `/repos/${repoFullName}/deployments?sha=${headSha}&per_page=1`,
       token,
+      baseUrl,
     );
 
     if (!deployments.length) return undefined;
@@ -474,6 +518,7 @@ async function fetchDeployment(
     const statuses = await ghFetch<{ state: string; environment_url?: string }[]>(
       `/repos/${repoFullName}/deployments/${deployment.id}/statuses?per_page=1`,
       token,
+      baseUrl,
     );
 
     if (!statuses.length) {
@@ -529,8 +574,8 @@ interface GraphQLPullRequestData {
 
 type GraphQLPullRequest = NonNullable<NonNullable<GraphQLPullRequestData['repository']>['pullRequest']>;
 
-async function ghGraphQL<T>(token: string, query: string, variables: Record<string, unknown>): Promise<T | null> {
-  const res = await fetch('https://api.github.com/graphql', {
+async function ghGraphQL<T>(token: string, query: string, variables: Record<string, unknown>, graphqlUrl: string): Promise<T | null> {
+  const res = await fetch(graphqlUrl, {
     method: 'POST',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -545,7 +590,7 @@ async function ghGraphQL<T>(token: string, query: string, variables: Record<stri
   return data.data ?? null;
 }
 
-async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber: number): Promise<GraphQLPRDetails> {
+async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber: number, graphqlUrl: string): Promise<GraphQLPRDetails> {
   // GitHub REST API doesn't expose resolved/unresolved state or mergeable status reliably.
   // Use GraphQL which has isResolved on reviewThreads and mergeable on pullRequest.
   const [owner, repo] = repoFullName.split('/');
@@ -584,7 +629,7 @@ async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber
         repo,
         prNumber,
         after,
-      });
+      }, graphqlUrl);
 
       const pr: GraphQLPullRequest | undefined = data?.repository?.pullRequest;
       if (!pr) return { unresolvedCommentCount: 0, hasConflicts: false, additions: 0, deletions: 0 };

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -1,5 +1,6 @@
 import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo } from '../types';
 
+const CANONICAL_INSTANCE = 'https://github.com';
 const CANONICAL_BASE_URL = 'https://api.github.com';
 const CANONICAL_GRAPHQL_URL = 'https://api.github.com/graphql';
 const HYDRATE_CONCURRENCY = 5;
@@ -9,16 +10,22 @@ const MAX_PAGINATED_PAGES = 20;
 /**
  * Resolve REST API base from a user-facing instance URL. GitHub Enterprise Server
  * mounts the API at `/api/v3`; canonical github.com uses `api.github.com`.
+ * Defensive: if a caller passes the canonical instance URL (e.g. legacy data),
+ * route to the cloud REST endpoint instead of `https://github.com/api/v3`.
  */
 function resolveBaseUrl(instanceUrl?: string): string {
   if (!instanceUrl) return CANONICAL_BASE_URL;
-  return `${instanceUrl.replace(/\/+$/, '')}/api/v3`;
+  const stripped = instanceUrl.replace(/\/+$/, '');
+  if (stripped === CANONICAL_INSTANCE) return CANONICAL_BASE_URL;
+  return `${stripped}/api/v3`;
 }
 
 /** Resolve GraphQL endpoint URL from a user-facing instance URL. */
 function resolveGraphQLUrl(instanceUrl?: string): string {
   if (!instanceUrl) return CANONICAL_GRAPHQL_URL;
-  return `${instanceUrl.replace(/\/+$/, '')}/api/graphql`;
+  const stripped = instanceUrl.replace(/\/+$/, '');
+  if (stripped === CANONICAL_INSTANCE) return CANONICAL_GRAPHQL_URL;
+  return `${stripped}/api/graphql`;
 }
 
 let lastRateLimit: RateLimitInfo | null = null;

--- a/src/shared/api/gitlab.test.ts
+++ b/src/shared/api/gitlab.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   mapGLPipelineStatus,
   deriveGLReviewStatus,
+  getAuthenticatedUser,
   getUserProjects,
   fetchMergeRequests,
   checkIfMerged,
@@ -256,3 +257,57 @@ function glJsonResponse(body: unknown): Response {
     headers: { get: () => null },
   } as unknown as Response;
 }
+
+describe('GitLab self-managed URL routing', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('getAuthenticatedUser hits gitlab.com/api/v4 when no instanceUrl is provided', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(glJsonResponse({ username: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0]).toBe('https://gitlab.com/api/v4/user');
+  });
+
+  it('getAuthenticatedUser routes to {instanceUrl}/api/v4 for self-managed', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(glJsonResponse({ username: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token', 'https://gitlab.example.com');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://gitlab.example.com/api/v4/user');
+  });
+
+  it('getAuthenticatedUser strips trailing slashes from instanceUrl', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(glJsonResponse({ username: 'me', avatar_url: '' }));
+    await getAuthenticatedUser('token', 'https://gitlab.example.com/');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://gitlab.example.com/api/v4/user');
+  });
+
+  it('getUserProjects routes to the self-managed base', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(glResponse([{ path_with_namespace: 'team/proj' }], null));
+    await getUserProjects('token', 'https://gitlab.example.com');
+    const url = vi.mocked(globalThis.fetch).mock.calls[0][0] as string;
+    expect(url.startsWith('https://gitlab.example.com/api/v4/projects?')).toBe(true);
+  });
+
+  it('mergeMergeRequest routes to the self-managed base', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({ ok: true } as Response);
+    await mergeMergeRequest('token', 'team/proj', 42, 'https://gitlab.example.com');
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://gitlab.example.com/api/v4/projects/team%2Fproj/merge_requests/42/merge');
+  });
+
+  it('checkIfMerged routes to the self-managed base', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(glJsonResponse({ state: 'merged' }));
+    const merged = await checkIfMerged('token', 'team/proj', 42, 'https://gitlab.example.com');
+    expect(merged).toBe(true);
+    expect(vi.mocked(globalThis.fetch).mock.calls[0][0])
+      .toBe('https://gitlab.example.com/api/v4/projects/team%2Fproj/merge_requests/42');
+  });
+});

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -1,6 +1,12 @@
 import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo } from '../types';
 
-const BASE_URL = 'https://gitlab.com/api/v4';
+const CANONICAL_INSTANCE = 'https://gitlab.com';
+
+/** Resolve the REST v4 base URL from a user-facing instance URL (canonical default when absent). */
+function resolveBaseUrl(instanceUrl?: string): string {
+  const root = instanceUrl ?? CANONICAL_INSTANCE;
+  return `${root.replace(/\/+$/, '')}/api/v4`;
+}
 
 let lastRateLimit: RateLimitInfo | null = null;
 
@@ -32,8 +38,8 @@ export class GitLabAPIError extends Error {
   }
 }
 
-async function glFetch<T>(path: string, token: string): Promise<T> {
-  const res = await fetch(`${BASE_URL}${path}`, {
+async function glFetch<T>(path: string, token: string, baseUrl: string): Promise<T> {
+  const res = await fetch(`${baseUrl}${path}`, {
     headers: {
       'PRIVATE-TOKEN': token,
     },
@@ -93,18 +99,19 @@ interface GLDeployment {
   environment: { name: string; external_url?: string };
 }
 
-export async function getAuthenticatedUser(token: string): Promise<{ username: string; avatar_url: string }> {
-  return glFetch('/user', token);
+export async function getAuthenticatedUser(token: string, instanceUrl?: string): Promise<{ username: string; avatar_url: string }> {
+  return glFetch('/user', token, resolveBaseUrl(instanceUrl));
 }
 
-export async function getUserProjects(token: string): Promise<{ path_with_namespace: string }[]> {
+export async function getUserProjects(token: string, instanceUrl?: string): Promise<{ path_with_namespace: string }[]> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
   // Paginate through all projects (GitLab returns x-next-page header)
   const allProjects: { path_with_namespace: string }[] = [];
   let page = 1;
   const maxPages = 10; // safety limit: 1000 projects
 
   while (page <= maxPages) {
-    const res = await fetch(`${BASE_URL}/projects?membership=true&order_by=last_activity_at&per_page=100&page=${page}`, {
+    const res = await fetch(`${baseUrl}/projects?membership=true&order_by=last_activity_at&per_page=100&page=${page}`, {
       headers: { 'PRIVATE-TOKEN': token },
     });
     if (!res.ok) {
@@ -126,10 +133,12 @@ export async function mergeMergeRequest(
   token: string,
   projectPath: string,
   mrIid: number,
+  instanceUrl?: string,
 ): Promise<{ success: boolean; message: string }> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
   const encodedPath = encodeURIComponent(projectPath);
   try {
-    const res = await fetch(`${BASE_URL}/projects/${encodedPath}/merge_requests/${mrIid}/merge`, {
+    const res = await fetch(`${baseUrl}/projects/${encodedPath}/merge_requests/${mrIid}/merge`, {
       method: 'PUT',
       headers: {
         'PRIVATE-TOKEN': token,
@@ -146,10 +155,11 @@ export async function mergeMergeRequest(
   }
 }
 
-export async function checkIfMerged(token: string, projectPath: string, mrIid: number): Promise<boolean> {
+export async function checkIfMerged(token: string, projectPath: string, mrIid: number, instanceUrl?: string): Promise<boolean> {
   try {
+    const baseUrl = resolveBaseUrl(instanceUrl);
     const encodedPath = encodeURIComponent(projectPath);
-    const mr = await glFetch<{ state: string }>(`/projects/${encodedPath}/merge_requests/${mrIid}`, token);
+    const mr = await glFetch<{ state: string }>(`/projects/${encodedPath}/merge_requests/${mrIid}`, token, baseUrl);
     return mr.state === 'merged';
   } catch {
     return false;
@@ -160,16 +170,19 @@ export async function fetchMergeRequests(
   token: string,
   projectPath: string,
   username: string,
+  instanceUrl?: string,
 ): Promise<PullRequest[]> {
+  const baseUrl = resolveBaseUrl(instanceUrl);
   const encodedPath = encodeURIComponent(projectPath);
 
   const mrs = await glFetch<GLMergeRequest[]>(
     `/projects/${encodedPath}/merge_requests?state=opened&per_page=50`,
     token,
+    baseUrl,
   );
 
   const results = await Promise.all(
-    mrs.map((mr) => hydrateMR(token, encodedPath, projectPath, mr, username)),
+    mrs.map((mr) => hydrateMR(token, baseUrl, encodedPath, projectPath, mr, username)),
   );
 
   return results;
@@ -177,6 +190,7 @@ export async function fetchMergeRequests(
 
 async function hydrateMR(
   token: string,
+  baseUrl: string,
   encodedPath: string,
   projectPath: string,
   mr: GLMergeRequest,
@@ -186,13 +200,15 @@ async function hydrateMR(
     glFetch<GLDiscussion[]>(
       `/projects/${encodedPath}/merge_requests/${mr.iid}/discussions`,
       token,
+      baseUrl,
     ),
     glFetch<GLApproval>(
       `/projects/${encodedPath}/merge_requests/${mr.iid}/approvals`,
       token,
+      baseUrl,
     ),
-    fetchDeployment(token, encodedPath, mr.sha),
-    fetchDiffStats(token, encodedPath, mr.iid),
+    fetchDeployment(token, baseUrl, encodedPath, mr.sha),
+    fetchDiffStats(token, baseUrl, encodedPath, mr.iid),
   ]);
 
   const unresolvedNotes = discussions.flatMap((d) =>
@@ -208,7 +224,7 @@ async function hydrateMR(
   // head_pipeline can be null even when pipelines exist (timing, detached pipelines)
   let pipeline = mr.head_pipeline;
   if (!pipeline) {
-    pipeline = await fetchLatestPipeline(token, encodedPath, mr.source_branch);
+    pipeline = await fetchLatestPipeline(token, baseUrl, encodedPath, mr.source_branch);
   }
 
   const ciStatus = mapGLPipelineStatus(pipeline?.status);
@@ -255,6 +271,7 @@ async function hydrateMR(
 
 async function fetchDiffStats(
   token: string,
+  baseUrl: string,
   encodedPath: string,
   mrIid: number,
 ): Promise<{ additions: number; deletions: number } | undefined> {
@@ -262,6 +279,7 @@ async function fetchDiffStats(
     const response = await glFetch<{ overflow?: boolean; changes: { diff: string }[] }>(
       `/projects/${encodedPath}/merge_requests/${mrIid}/changes?access_raw_diffs=false`,
       token,
+      baseUrl,
     );
     if (response.overflow) return undefined;
     let additions = 0;
@@ -280,6 +298,7 @@ async function fetchDiffStats(
 
 async function fetchLatestPipeline(
   token: string,
+  baseUrl: string,
   encodedPath: string,
   ref: string,
 ): Promise<{ status: string; web_url: string; duration: number | null } | null> {
@@ -287,6 +306,7 @@ async function fetchLatestPipeline(
     const pipelines = await glFetch<{ id: number; status: string; web_url: string }[]>(
       `/projects/${encodedPath}/pipelines?ref=${encodeURIComponent(ref)}&per_page=1&order_by=id&sort=desc`,
       token,
+      baseUrl,
     );
     if (!pipelines.length) return null;
     return { status: pipelines[0].status, web_url: pipelines[0].web_url, duration: null };
@@ -297,6 +317,7 @@ async function fetchLatestPipeline(
 
 async function fetchDeployment(
   token: string,
+  baseUrl: string,
   encodedPath: string,
   sha: string,
 ): Promise<PullRequest['deployment']> {
@@ -304,6 +325,7 @@ async function fetchDeployment(
     const deployments = await glFetch<GLDeployment[]>(
       `/projects/${encodedPath}/deployments?order_by=created_at&sort=desc&per_page=1&sha=${sha}`,
       token,
+      baseUrl,
     );
 
     if (!deployments.length) return undefined;

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -2,10 +2,15 @@ import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo } from '../type
 
 const CANONICAL_INSTANCE = 'https://gitlab.com';
 
-/** Resolve the REST v4 base URL from a user-facing instance URL (canonical default when absent). */
+/**
+ * Resolve the REST v4 base URL from a user-facing instance URL.
+ * Falls back to the canonical service when no instance URL is set, and
+ * defensively maps a canonical-matching instance URL back to the canonical
+ * base (so legacy data with `instanceUrl: 'https://gitlab.com'` works).
+ */
 function resolveBaseUrl(instanceUrl?: string): string {
-  const root = instanceUrl ?? CANONICAL_INSTANCE;
-  return `${root.replace(/\/+$/, '')}/api/v4`;
+  const root = (instanceUrl ?? CANONICAL_INSTANCE).replace(/\/+$/, '');
+  return `${root}/api/v4`;
 }
 
 let lastRateLimit: RateLimitInfo | null = null;

--- a/src/shared/instanceUrl.test.ts
+++ b/src/shared/instanceUrl.test.ts
@@ -42,6 +42,45 @@ describe('normalizeInstanceUrl', () => {
   it('preserves port', () => {
     expect(normalizeInstanceUrl('https://gitlab.example.com:8443')).toBe('https://gitlab.example.com:8443');
   });
+
+  describe('with platform argument', () => {
+    it('strips a trailing /api/v4 for GitLab', () => {
+      expect(normalizeInstanceUrl('https://gitlab.example.com/api/v4', 'gitlab'))
+        .toBe('https://gitlab.example.com');
+    });
+
+    it('strips a trailing /api/v3 for GitHub', () => {
+      expect(normalizeInstanceUrl('https://github.example.com/api/v3', 'github'))
+        .toBe('https://github.example.com');
+    });
+
+    it('strips a trailing /api/graphql for GitHub', () => {
+      expect(normalizeInstanceUrl('https://github.example.com/api/graphql', 'github'))
+        .toBe('https://github.example.com');
+    });
+
+    it('returns null when the cleaned URL matches the canonical service (GitHub)', () => {
+      expect(normalizeInstanceUrl('https://github.com', 'github')).toBeNull();
+      expect(normalizeInstanceUrl('https://github.com/', 'github')).toBeNull();
+    });
+
+    it('returns null when the cleaned URL matches the canonical service (GitLab)', () => {
+      expect(normalizeInstanceUrl('https://gitlab.com', 'gitlab')).toBeNull();
+      expect(normalizeInstanceUrl('https://gitlab.com/', 'gitlab')).toBeNull();
+    });
+
+    it('returns null when stripping an API suffix lands on the canonical', () => {
+      expect(normalizeInstanceUrl('https://gitlab.com/api/v4', 'gitlab')).toBeNull();
+      expect(normalizeInstanceUrl('https://github.com/api/v3', 'github')).toBeNull();
+    });
+
+    it('keeps a real self-hosted URL untouched when there is no API suffix', () => {
+      expect(normalizeInstanceUrl('https://gitlab.example.com', 'gitlab'))
+        .toBe('https://gitlab.example.com');
+      expect(normalizeInstanceUrl('https://github.acme.com', 'github'))
+        .toBe('https://github.acme.com');
+    });
+  });
 });
 
 describe('getInstanceUrl', () => {

--- a/src/shared/instanceUrl.test.ts
+++ b/src/shared/instanceUrl.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CANONICAL_INSTANCE_URLS,
+  getDisplayHost,
+  getInstanceUrl,
+  isSelfHosted,
+  normalizeInstanceUrl,
+} from './instanceUrl';
+
+describe('normalizeInstanceUrl', () => {
+  it('returns null for empty / whitespace / nullish inputs', () => {
+    expect(normalizeInstanceUrl(null)).toBeNull();
+    expect(normalizeInstanceUrl(undefined)).toBeNull();
+    expect(normalizeInstanceUrl('')).toBeNull();
+    expect(normalizeInstanceUrl('   ')).toBeNull();
+  });
+
+  it('strips trailing slashes', () => {
+    expect(normalizeInstanceUrl('https://gitlab.example.com/')).toBe('https://gitlab.example.com');
+    expect(normalizeInstanceUrl('https://gitlab.example.com///')).toBe('https://gitlab.example.com');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(normalizeInstanceUrl('  https://gitlab.example.com  ')).toBe('https://gitlab.example.com');
+  });
+
+  it('rejects non-https URLs', () => {
+    expect(normalizeInstanceUrl('http://gitlab.example.com')).toBeNull();
+    expect(normalizeInstanceUrl('ftp://gitlab.example.com')).toBeNull();
+  });
+
+  it('rejects malformed URLs', () => {
+    expect(normalizeInstanceUrl('not a url')).toBeNull();
+    expect(normalizeInstanceUrl('gitlab.example.com')).toBeNull(); // missing scheme
+    expect(normalizeInstanceUrl('https://')).toBeNull();
+  });
+
+  it('preserves a non-trivial path', () => {
+    expect(normalizeInstanceUrl('https://example.com/gitlab')).toBe('https://example.com/gitlab');
+  });
+
+  it('preserves port', () => {
+    expect(normalizeInstanceUrl('https://gitlab.example.com:8443')).toBe('https://gitlab.example.com:8443');
+  });
+});
+
+describe('getInstanceUrl', () => {
+  it('returns the canonical service URL when no instanceUrl is set', () => {
+    expect(getInstanceUrl({ platform: 'github' })).toBe(CANONICAL_INSTANCE_URLS.github);
+    expect(getInstanceUrl({ platform: 'gitlab' })).toBe(CANONICAL_INSTANCE_URLS.gitlab);
+    expect(getInstanceUrl({ platform: 'bitbucket' })).toBe(CANONICAL_INSTANCE_URLS.bitbucket);
+  });
+
+  it('returns the configured instance URL when present', () => {
+    expect(getInstanceUrl({ platform: 'github', instanceUrl: 'https://github.example.com' }))
+      .toBe('https://github.example.com');
+  });
+
+  it('normalizes the configured URL', () => {
+    expect(getInstanceUrl({ platform: 'gitlab', instanceUrl: 'https://gitlab.example.com/' }))
+      .toBe('https://gitlab.example.com');
+  });
+
+  it('falls back to canonical when configured URL is invalid', () => {
+    expect(getInstanceUrl({ platform: 'github', instanceUrl: 'not-a-url' }))
+      .toBe(CANONICAL_INSTANCE_URLS.github);
+  });
+});
+
+describe('isSelfHosted', () => {
+  it('returns false when no instanceUrl is set', () => {
+    expect(isSelfHosted({ platform: 'github' })).toBe(false);
+  });
+
+  it('returns false when instanceUrl matches the canonical service', () => {
+    expect(isSelfHosted({ platform: 'gitlab', instanceUrl: 'https://gitlab.com' })).toBe(false);
+    expect(isSelfHosted({ platform: 'gitlab', instanceUrl: 'https://gitlab.com/' })).toBe(false);
+  });
+
+  it('returns true for a different host', () => {
+    expect(isSelfHosted({ platform: 'gitlab', instanceUrl: 'https://gitlab.example.com' })).toBe(true);
+    expect(isSelfHosted({ platform: 'github', instanceUrl: 'https://github.acme.com' })).toBe(true);
+  });
+
+  it('returns false when instanceUrl is invalid (treated as canonical)', () => {
+    expect(isSelfHosted({ platform: 'github', instanceUrl: 'invalid' })).toBe(false);
+  });
+});
+
+describe('getDisplayHost', () => {
+  it('returns null for canonical accounts', () => {
+    expect(getDisplayHost({
+      platform: 'github',
+      token: 't',
+      username: 'u',
+    })).toBeNull();
+  });
+
+  it('returns the host for self-hosted accounts', () => {
+    expect(getDisplayHost({
+      platform: 'gitlab',
+      token: 't',
+      username: 'u',
+      instanceUrl: 'https://gitlab.example.com',
+    })).toBe('gitlab.example.com');
+  });
+
+  it('includes port in host when present', () => {
+    expect(getDisplayHost({
+      platform: 'github',
+      token: 't',
+      username: 'u',
+      instanceUrl: 'https://github.example.com:8443',
+    })).toBe('github.example.com:8443');
+  });
+});

--- a/src/shared/instanceUrl.ts
+++ b/src/shared/instanceUrl.ts
@@ -18,11 +18,25 @@ export function isSelfHosted(account: { platform: Platform; instanceUrl?: string
   return !!normalized && normalized !== CANONICAL_INSTANCE_URLS[account.platform];
 }
 
+/** Platform-specific API path suffixes to strip when a user pastes an API endpoint. */
+const API_PATH_SUFFIXES: Record<Platform, RegExp> = {
+  github: /\/api\/(?:v3|graphql)$/i,
+  gitlab: /\/api\/v4$/i,
+  bitbucket: /\/2\.0$/, // not used today (Phase 3 deferred) but harmless to define
+};
+
 /**
  * Normalize a user-entered instance URL: trim whitespace, drop trailing slash,
  * require https. Returns null if the input is empty or invalid.
+ *
+ * When `platform` is provided:
+ *   - strips well-known API path suffixes (e.g. `/api/v4`, `/api/v3`, `/api/graphql`)
+ *     so users can paste an API endpoint by mistake without breaking us;
+ *   - returns null when the cleaned result matches the canonical service URL,
+ *     so the caller can treat that case as "use cloud" rather than persisting
+ *     a bogus self-hosted instance.
  */
-export function normalizeInstanceUrl(input: string | undefined | null): string | null {
+export function normalizeInstanceUrl(input: string | undefined | null, platform?: Platform): string | null {
   if (!input) return null;
   const trimmed = input.trim().replace(/\/+$/, '');
   if (!trimmed) return null;
@@ -30,7 +44,12 @@ export function normalizeInstanceUrl(input: string | undefined | null): string |
     const url = new URL(trimmed);
     if (url.protocol !== 'https:') return null;
     if (!url.hostname) return null;
-    return `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`;
+    let normalized = `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`;
+    if (platform) {
+      normalized = normalized.replace(API_PATH_SUFFIXES[platform], '');
+      if (normalized === CANONICAL_INSTANCE_URLS[platform]) return null;
+    }
+    return normalized;
   } catch {
     return null;
   }

--- a/src/shared/instanceUrl.ts
+++ b/src/shared/instanceUrl.ts
@@ -1,0 +1,75 @@
+import type { Platform, PlatformAccount } from './types';
+
+/** User-facing root URL of the canonical hosted service for each platform. */
+export const CANONICAL_INSTANCE_URLS: Record<Platform, string> = {
+  github: 'https://github.com',
+  gitlab: 'https://gitlab.com',
+  bitbucket: 'https://bitbucket.org',
+};
+
+/** Resolve the user-facing instance URL for an account (canonical default if not self-hosted). */
+export function getInstanceUrl(account: { platform: Platform; instanceUrl?: string }): string {
+  return normalizeInstanceUrl(account.instanceUrl) ?? CANONICAL_INSTANCE_URLS[account.platform];
+}
+
+/** True when the account points at something other than the canonical service. */
+export function isSelfHosted(account: { platform: Platform; instanceUrl?: string }): boolean {
+  const normalized = normalizeInstanceUrl(account.instanceUrl);
+  return !!normalized && normalized !== CANONICAL_INSTANCE_URLS[account.platform];
+}
+
+/**
+ * Normalize a user-entered instance URL: trim whitespace, drop trailing slash,
+ * require https. Returns null if the input is empty or invalid.
+ */
+export function normalizeInstanceUrl(input: string | undefined | null): string | null {
+  if (!input) return null;
+  const trimmed = input.trim().replace(/\/+$/, '');
+  if (!trimmed) return null;
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol !== 'https:') return null;
+    if (!url.hostname) return null;
+    return `${url.protocol}//${url.host}${url.pathname.replace(/\/+$/, '')}`;
+  } catch {
+    return null;
+  }
+}
+
+/** Convenience: short host display for UI subtitles. Returns null when canonical. */
+export function getDisplayHost(account: PlatformAccount): string | null {
+  if (!isSelfHosted(account)) return null;
+  try {
+    return new URL(getInstanceUrl(account)).host;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Request runtime host permission for a self-hosted instance. Must be invoked
+ * from a user-gesture handler (e.g. the Connect button click). Returns true
+ * when the user grants access.
+ */
+export async function requestInstanceHostPermission(instanceUrl: string): Promise<boolean> {
+  const normalized = normalizeInstanceUrl(instanceUrl);
+  if (!normalized) return false;
+  const origin = `${normalized}/*`;
+  return new Promise((resolve) => {
+    chrome.permissions.request({ origins: [origin] }, (granted) => {
+      resolve(!!granted);
+    });
+  });
+}
+
+/** Check whether host permission has already been granted for an instance URL. */
+export async function hasInstanceHostPermission(instanceUrl: string): Promise<boolean> {
+  const normalized = normalizeInstanceUrl(instanceUrl);
+  if (!normalized) return false;
+  const origin = `${normalized}/*`;
+  return new Promise((resolve) => {
+    chrome.permissions.contains({ origins: [origin] }, (granted) => {
+      resolve(!!granted);
+    });
+  });
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -7,6 +7,8 @@ export interface PlatformAccount {
   token: string;
   username: string;
   avatarUrl?: string;
+  /** Set for self-hosted instances (GitHub Enterprise Server, GitLab self-managed). Absent ⇒ canonical service. */
+  instanceUrl?: string;
 }
 
 // === Pull Requests ===


### PR DESCRIPTION
Closes #1.

## Summary

Adds opt-in support for **GitHub Enterprise Server** and **GitLab self-managed** instances. Bitbucket Data Center is deferred (different API entirely; tracked in #1 for a follow-up if demand surfaces).

Backward compatible: existing accounts have no `instanceUrl` field and continue to hit the canonical hosts. Users on `github.com`/`gitlab.com` see no UI change unless they toggle the new option.

## What changed

- New optional `instanceUrl` field on `PlatformAccount`. Absent ⇒ canonical service.
- GitHub API client (REST + GraphQL) and GitLab API client take an optional `instanceUrl` parameter, parameterizing the base URL (`/api/v3` for GHES, `/api/v4` for GitLab).
- Setup page: new "Self-hosted instance?" toggle (GitHub and GitLab only) revealing a single Instance URL input. Token-link helper points at the user's instance. HTTPS-only URL validation.
- Runtime host permission request (`chrome.permissions.request`) before the first API call to a self-hosted host. Manifest declares `optional_host_permissions: ["https://*/*"]` (Chrome) and `optional_permissions` (Firefox).
- Settings → Accounts list shows the instance host as a subtitle (`@user · gitlab.example.com`) for self-hosted accounts.
- Plan document at `docs/plans/self-hosted-instances.md`.

## Why no Bitbucket Data Center yet

Bitbucket DC uses a different REST API path (`/rest/api/1.0/...`), different auth (HTTP access tokens vs. Cloud's `email:token` Basic), and entirely different data shapes. Implementing it would effectively be a new platform client (~5-10 days). Deferring until there's measurable demand. Toggle is hidden for Bitbucket so users aren't misled.

## Status: needs real-instance testing

I implemented this without access to a real GitHub Enterprise Server or GitLab self-managed instance, so the code compiles and unit tests pass but **end-to-end behavior against a real self-hosted server has not been verified.** Help wanted before merging.

## Test plan

- [x] Typecheck (`npm run typecheck`) — passes
- [x] Lint (`npm run lint`) — passes
- [x] Unit tests (`npx vitest run`) — 82/82 passing
- [x] Production builds (`npm run build`, `npm run build:firefox`) — both succeed; manifests emit correct `optional_host_permissions` / `optional_permissions`
- [x] Existing canonical (`github.com`, `gitlab.com`) accounts keep working — no signature changes that break absent `instanceUrl`
- [ ] Connect a real **GitLab self-managed** instance: token validation, repo list, PR list, CI status, discussions, approvals, deployments, merge from popup
- [ ] Connect a real **GitHub Enterprise Server** instance: token validation, repo list (incl. orgs), PR list, CI/check-runs, GraphQL review threads, deployments, merge from popup
- [ ] Confirm Chrome shows the host-permission prompt on first connect, and the connection is blocked when permission is denied
- [ ] Confirm token rotation / re-auth replaces the stored `instanceUrl` correctly

## Notes for review

- Pagination (`getNextPagePath`) now derives the expected origin from the configured base URL, so GHES `Link` headers pointing at `ghes.example.com/api/v3/...` are followed correctly. Existing test still covers the canonical path.
- The optional broad host permission (`https://*/*`) is **only requested when a user explicitly enters a self-hosted URL** — users who never toggle self-hosted never see a permission prompt. Worth flagging in the Chrome Web Store re-review notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support connecting to self‑hosted Git instances (GitHub Enterprise Server, GitLab, Bitbucket Data Center).
  * "Self‑hosted instance" toggle and Instance URL input during account setup; instance shown in Settings.
  * Token/help links, repo listing, PR/MR actions and polling use the configured instance URL.

* **Documentation**
  * Added a phased plan and verification criteria for self‑hosted instance support.

* **Chores**
  * Browser optional host-permission prompt and manifest entries for runtime instance URL permissions.

* **Tests**
  * Added tests validating instance-URL normalization and per‑platform routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->