### PR TITLE
Detect and group stacked PRs in the dashboard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ src/
       TriageSummary.tsx          # Urgency filter chip bar (icon+count chips with tooltips)
     utils/
       urgency.ts                 # Urgency classification, filter predicate, count computation, display metadata
+      stacks.ts                  # Stack detection: parent/child graph from baseBranch→headRef, position, blocked-by-parent check
     index.css                    # Tailwind imports + dark scrollbar styles
   shared/
     types.ts                     # TypeScript types (PullRequest, Platform, Message, UrgencyCategory, etc.)
@@ -134,6 +135,7 @@ The extension works fully without DeployHQ. This integration is entirely opt-in 
 - **Stale PR exclusion** — Configurable threshold; stale PRs are dimmed in UI, excluded from badge count and notifications
 - **Merge from dashboard** — Merge button in PR title row for all platforms; disabled when CI failing, conflicts, or draft; confirm step prevents accidental merges; respects branch protection rules; shows Merged (purple) state until poll refreshes
 - **Urgency filters as chips, not tabs** — Compact icon+count chips in a triage bar (not a new tab) keep the UI lightweight; single-select toggle; counts computed from tab-filtered list so summary always shows full picture; stale is exclusive (no other urgency flags); filter state is ephemeral (resets on tab switch, no persistence)
+- **Stacked PR detection** — Parent/child relationships derived by matching each PR's `baseBranch` to other open PRs' `headRef` within the same repo+platform; works across all three platforms with no platform-specific API (universal heuristic, not e.g. GitLab MR dependencies); stack grouping applies only in default sort mode (recent/oldest/long_wait stay chronological); a `stack_blocked` urgency flags PRs whose ancestor chain has any unmerged parent in the list
 
 ## Features
 
@@ -155,7 +157,8 @@ The extension works fully without DeployHQ. This integration is entirely opt-in 
 - **Token guidance** — Pre-filled token links, required scopes panel, platform-specific "Missing repos?" callouts
 - **Dark scrollbar** — Themed to match dark UI
 - **Merge PRs** — Merge button with confirm/cancel for GitHub, GitLab, and Bitbucket; disabled for drafts, conflicts, CI failures
-- **Urgency filters** — Triage chip bar above PR list with icon+count chips (CI failing, Changes requested, Review requested, Conflicts, Stale) plus All chip; single-select toggle filters the list; counts scoped to active tab; resets on tab switch
+- **Urgency filters** — Triage chip bar above PR list with icon+count chips (CI failing, Changes requested, Review requested, Conflicts, Stack blocked, Stale) plus All chip; single-select toggle filters the list; counts scoped to active tab; resets on tab switch
+- **Stacked PRs** — Detected by matching `baseBranch` to other PRs' `headRef` per repo; stack members group together with parents above children, child rows indent and share an indigo left accent bar; `🥞 N/M` position chip with tooltip carrying parent status; "Stack blocked" urgency chip appears when a PR waits on an unmerged ancestor
 - **Diff stats** — Shows `+N -N` additions/deletions per PR; GitHub via GraphQL, GitLab via changes endpoint (with overflow detection), Bitbucket via paginated diffstat API
 - **PR description preview** — Expandable "Show description" toggle below each PR row; truncated at 500 chars with scrollable container; whitespace-only descriptions are hidden
 - **Pending reviewers** — Badge showing count of reviewers who haven't submitted a review yet

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { PullRequest, Message, DeployHQServer } from '@/shared/types';
+import type { StackInfo } from '../utils/stacks';
 import CIBadge from './CIBadge';
 import PlatformIcon from './PlatformIcon';
 
@@ -9,9 +10,12 @@ interface PRItemProps {
   pinned?: boolean;
   onMerged?: () => void;
   focused?: boolean;
+  stackInfo?: StackInfo;
+  parentUnmerged?: boolean;
+  parentNumber?: number;
 }
 
-export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: PRItemProps) {
+export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, stackInfo, parentUnmerged, parentNumber }: PRItemProps) {
   const [mergeState, setMergeState] = useState<'idle' | 'confirm' | 'merging' | 'merged' | 'error'>('idle');
   const [mergeError, setMergeError] = useState('');
   const [branchState, setBranchState] = useState<'idle' | 'confirm' | 'deleting' | 'deleted' | 'error'>('idle');
@@ -110,8 +114,19 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
     }
   }
 
+  const stackDepth = stackInfo?.depth ?? 0;
+  const inStack = Boolean(stackInfo && stackInfo.total > 1);
+  // Stack members share a left accent bar and children indent so dependency
+  // direction reads top-down at a glance.
+  const stackPaddingClass = inStack && stackDepth > 0 ? 'pl-8 pr-4' : 'px-4';
+  const stackBorderClass = inStack
+    ? 'border-l-[3px] border-indigo-400/70 dark:border-indigo-500/70'
+    : '';
+
   return (
-    <div className={`px-4 py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/30 transition-colors ${isDimmed ? 'opacity-50' : ''} ${focused ? 'ring-1 ring-inset ring-radar-500/60 bg-gray-50 dark:bg-gray-800/40' : ''}`}>
+    <div
+      className={`${stackPaddingClass} py-3 border-b border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/30 transition-colors ${stackBorderClass} ${isDimmed ? 'opacity-50' : ''} ${focused ? 'ring-1 ring-inset ring-radar-500/60 bg-gray-50 dark:bg-gray-800/40' : ''}`}
+    >
       <a
         href={pr.url}
         target="_blank"
@@ -232,6 +247,19 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused }: P
             <div className="text-[11px] text-gray-500 mt-0.5 flex items-center gap-1.5">
               <span>{pr.repoFullName} #{pr.number}</span>
               <span className="text-gray-400 dark:text-gray-500">by {pr.author}</span>
+              {stackInfo && stackInfo.total > 1 && (
+                <span
+                  className="text-[9px] px-1.5 py-px rounded bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 font-medium"
+                  title={parentUnmerged && parentNumber
+                    ? `Stack ${stackInfo.position}/${stackInfo.total} — waiting on #${parentNumber}`
+                    : parentNumber
+                      ? `Stack ${stackInfo.position}/${stackInfo.total} — based on #${parentNumber}`
+                      : `Stack ${stackInfo.position}/${stackInfo.total} — base of stack`}
+                  aria-label={`Stack position ${stackInfo.position} of ${stackInfo.total}${parentUnmerged && parentNumber ? `, waiting on PR ${parentNumber}` : ''}`}
+                >
+                  <span aria-hidden="true">&#x1F95E;</span> {stackInfo.position}/{stackInfo.total}
+                </span>
+              )}
               {pr.isAuthor && (
                 <span className="text-[9px] px-1.5 py-px rounded bg-radar-100 dark:bg-radar-900/50 text-radar-700 dark:text-radar-400 font-medium">
                   Author

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -3,6 +3,7 @@ import type { AppView, DashboardTab, PullRequest, SortMode, UrgencyCategory } fr
 import { getWatchedRepos, getCachedPRs, getSettings, saveSettings, getInstallDate, isStarPromptDismissed, dismissStarPrompt } from '@/shared/storage';
 import { STORE_URL, GITHUB_REPO_URL } from '@/shared/constants';
 import { matchesUrgencyFilter, computeUrgencyCounts } from '../utils/urgency';
+import { detectStacks, isStackBlocked } from '../utils/stacks';
 import PRItem from '../components/PRItem';
 import TriageSummary from '../components/TriageSummary';
 import KeyboardShortcuts from '../components/KeyboardShortcuts';
@@ -156,6 +157,17 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
   // Reset focused index when list changes
   useEffect(() => { setFocusedIndex(-1); }, [tab, urgencyFilter, search]);
 
+  // Stack detection runs over the full PR list so parents on other tabs still resolve.
+  const stacks = useMemo(() => detectStacks(prs), [prs]);
+  const prById = useMemo(() => new Map(prs.map((p) => [p.id, p])), [prs]);
+  const blockedIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const pr of prs) {
+      if (isStackBlocked(pr.id, stacks, prById)) ids.add(pr.id);
+    }
+    return ids;
+  }, [prs, stacks, prById]);
+
   // Filter PRs by tab
   const filteredByTab = prs.filter((pr) => {
     if (tab === 'mine') return pr.isAuthor;
@@ -165,13 +177,13 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
 
   // Compute urgency counts from tab-filtered list (before urgency filter)
   const urgencyCounts = useMemo(
-    () => computeUrgencyCounts(filteredByTab, stalePRDays, longWaitDays),
-    [filteredByTab, stalePRDays, longWaitDays],
+    () => computeUrgencyCounts(filteredByTab, stalePRDays, longWaitDays, blockedIds),
+    [filteredByTab, stalePRDays, longWaitDays, blockedIds],
   );
 
   // Filter by urgency
   const filteredByUrgency = urgencyFilter
-    ? filteredByTab.filter((pr) => matchesUrgencyFilter(pr, urgencyFilter, stalePRDays, longWaitDays))
+    ? filteredByTab.filter((pr) => matchesUrgencyFilter(pr, urgencyFilter, stalePRDays, longWaitDays, blockedIds.has(pr.id)))
     : filteredByTab;
 
   // Filter by search
@@ -189,7 +201,7 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
   // Sort by priority first, then pinned within same priority tier, then date.
   // Explicit sort mode overrides default ordering. When long_wait filter is active,
   // surface the longest-waiting PRs first.
-  const filtered = [...searched].sort((a, b) => {
+  const sorted = [...searched].sort((a, b) => {
     if (sortMode === 'recent') {
       return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
     }
@@ -207,6 +219,12 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
     if (aPinned !== bPinned) return aPinned - bPinned;
     return new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
   });
+
+  // Group stack members together in default sort mode: anchor each stack at its
+  // highest-priority member's position, then list members root-first.
+  const filtered = (sortMode === 'default' && urgencyFilter !== 'long_wait')
+    ? groupStacks(sorted, stacks)
+    : sorted;
 
   // Keyboard navigation
   const filteredRef = useRef(filtered);
@@ -469,22 +487,66 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
           </div>
         ) : (
           <div ref={listRef}>
-            {filtered.map((pr, i) => (
-              <PRItem
-                key={pr.id}
-                pr={pr}
-                stalePRDays={stalePRDays}
-                pinned={pinnedRepos.has(`${pr.platform}:${pr.repoFullName}`)}
-                onMerged={triggerBackgroundRefresh}
-                focused={i === focusedIndex}
-              />
-            ))}
+            {filtered.map((pr, i) => {
+              const stackInfo = stacks.get(pr.id);
+              const parentPr = stackInfo?.parentId ? prById.get(stackInfo.parentId) : undefined;
+              return (
+                <PRItem
+                  key={pr.id}
+                  pr={pr}
+                  stalePRDays={stalePRDays}
+                  pinned={pinnedRepos.has(`${pr.platform}:${pr.repoFullName}`)}
+                  onMerged={triggerBackgroundRefresh}
+                  focused={i === focusedIndex}
+                  stackInfo={stackInfo}
+                  parentUnmerged={blockedIds.has(pr.id)}
+                  parentNumber={parentPr?.number}
+                />
+              );
+            })}
           </div>
         )}
       </div>
       {showShortcuts && <KeyboardShortcuts onClose={() => setShowShortcuts(false)} />}
     </div>
   );
+}
+
+function groupStacks(
+  sorted: PullRequest[],
+  stacks: Map<string, import('../utils/stacks').StackInfo>,
+): PullRequest[] {
+  const result: PullRequest[] = [];
+  const consumed = new Set<string>();
+
+  for (const pr of sorted) {
+    if (consumed.has(pr.id)) continue;
+    const info = stacks.get(pr.id);
+    if (!info) {
+      result.push(pr);
+      consumed.add(pr.id);
+      continue;
+    }
+
+    const members = sorted
+      .filter((p) => {
+        const i = stacks.get(p.id);
+        return i?.stackId === info.stackId && !consumed.has(p.id);
+      })
+      .sort((a, b) => {
+        const da = stacks.get(a.id)?.depth ?? 0;
+        const db = stacks.get(b.id)?.depth ?? 0;
+        if (da !== db) return da - db;
+        return a.number - b.number;
+      });
+
+    for (const m of members) {
+      result.push(m);
+      consumed.add(m.id);
+    }
+  }
+
+  return result;
 }
 
 function prPriority(pr: PullRequest, stalePRDays: number): number {

--- a/src/popup/utils/stacks.ts
+++ b/src/popup/utils/stacks.ts
@@ -1,0 +1,166 @@
+import type { PullRequest } from '@/shared/types';
+
+export interface StackInfo {
+  stackId: string;
+  parentId?: string;
+  parentNumber?: number;
+  childIds: string[];
+  rootId: string;
+  depth: number;
+  total: number;
+  position: number;
+}
+
+function stackKey(pr: PullRequest): string {
+  return `${pr.platform}:${pr.repoFullName}`;
+}
+
+export function detectStacks(prs: PullRequest[]): Map<string, StackInfo> {
+  // Index PRs by repo+platform key, then by head branch.
+  // Used to resolve a PR's parent (the PR whose head is this PR's base).
+  const byHead = new Map<string, Map<string, PullRequest>>();
+  for (const pr of prs) {
+    if (!pr.headRef) continue;
+    const key = stackKey(pr);
+    let inner = byHead.get(key);
+    if (!inner) {
+      inner = new Map();
+      byHead.set(key, inner);
+    }
+    if (!inner.has(pr.headRef)) inner.set(pr.headRef, pr);
+  }
+
+  // Compute parent and children for each PR.
+  const parentOf = new Map<string, PullRequest>();
+  const childrenOf = new Map<string, PullRequest[]>();
+  for (const pr of prs) {
+    if (!pr.baseBranch) continue;
+    const parent = byHead.get(stackKey(pr))?.get(pr.baseBranch);
+    if (!parent || parent.id === pr.id) continue;
+    parentOf.set(pr.id, parent);
+    const list = childrenOf.get(parent.id) ?? [];
+    list.push(pr);
+    childrenOf.set(parent.id, list);
+  }
+
+  // Walk each PR to its root and collect connected component members.
+  const result = new Map<string, StackInfo>();
+  const componentOf = new Map<string, string[]>(); // rootId -> all PR ids in component
+
+  function findRoot(pr: PullRequest): PullRequest {
+    let cur = pr;
+    const seen = new Set<string>([cur.id]);
+    while (true) {
+      const parent = parentOf.get(cur.id);
+      if (!parent || seen.has(parent.id)) return cur;
+      seen.add(parent.id);
+      cur = parent;
+    }
+  }
+
+  function collectComponent(root: PullRequest): string[] {
+    const ids: string[] = [];
+    const queue: PullRequest[] = [root];
+    const seen = new Set<string>();
+    while (queue.length > 0) {
+      const node = queue.shift()!;
+      if (seen.has(node.id)) continue;
+      seen.add(node.id);
+      ids.push(node.id);
+      for (const child of childrenOf.get(node.id) ?? []) {
+        if (!seen.has(child.id)) queue.push(child);
+      }
+    }
+    return ids;
+  }
+
+  for (const pr of prs) {
+    const hasParent = parentOf.has(pr.id);
+    const hasChildren = (childrenOf.get(pr.id)?.length ?? 0) > 0;
+    if (!hasParent && !hasChildren) continue;
+
+    const root = findRoot(pr);
+    let memberIds = componentOf.get(root.id);
+    if (!memberIds) {
+      memberIds = collectComponent(root);
+      componentOf.set(root.id, memberIds);
+    }
+
+    const parent = parentOf.get(pr.id);
+    const depth = computeDepth(pr, parentOf);
+
+    result.set(pr.id, {
+      stackId: root.id,
+      parentId: parent?.id,
+      parentNumber: parent?.number,
+      childIds: (childrenOf.get(pr.id) ?? []).map((c) => c.id),
+      rootId: root.id,
+      depth,
+      total: memberIds.length,
+      position: depth + 1,
+    });
+  }
+
+  return result;
+}
+
+function computeDepth(pr: PullRequest, parentOf: Map<string, PullRequest>): number {
+  let depth = 0;
+  let cur: PullRequest | undefined = parentOf.get(pr.id);
+  const seen = new Set<string>([pr.id]);
+  while (cur && !seen.has(cur.id)) {
+    seen.add(cur.id);
+    depth++;
+    cur = parentOf.get(cur.id);
+  }
+  return depth;
+}
+
+// True if any ancestor of this PR is open and unmerged.
+// A PR is "blocked" when it depends on a parent that hasn't landed yet.
+export function isStackBlocked(prId: string, stacks: Map<string, StackInfo>, prById: Map<string, PullRequest>): boolean {
+  const info = stacks.get(prId);
+  if (!info?.parentId) return false;
+  let cursorId: string | undefined = info.parentId;
+  const seen = new Set<string>([prId]);
+  while (cursorId && !seen.has(cursorId)) {
+    seen.add(cursorId);
+    const parent = prById.get(cursorId);
+    if (!parent) return false;
+    if (!parent.isMerged) return true;
+    cursorId = stacks.get(cursorId)?.parentId;
+  }
+  return false;
+}
+
+// Sort PRs to keep stack members adjacent, with parents before children.
+// Returns a comparator-friendly index for each PR.
+export function buildStackOrder(prs: PullRequest[], stacks: Map<string, StackInfo>): Map<string, number> {
+  const order = new Map<string, number>();
+  const prById = new Map(prs.map((p) => [p.id, p]));
+  const visited = new Set<string>();
+  let counter = 0;
+
+  function visit(prId: string) {
+    if (visited.has(prId)) return;
+    visited.add(prId);
+    order.set(prId, counter++);
+    const info = stacks.get(prId);
+    if (!info) return;
+    // Visit children in deterministic order (by PR number).
+    const childPrs = info.childIds
+      .map((id) => prById.get(id))
+      .filter((p): p is PullRequest => Boolean(p))
+      .sort((a, b) => a.number - b.number);
+    for (const child of childPrs) visit(child.id);
+  }
+
+  // Seed with root PRs first.
+  const roots = prs.filter((p) => {
+    const info = stacks.get(p.id);
+    return info && info.rootId === p.id;
+  });
+  for (const root of roots) visit(root.id);
+
+  return order;
+}

--- a/src/popup/utils/urgency.ts
+++ b/src/popup/utils/urgency.ts
@@ -4,6 +4,7 @@ export function getUrgencyCategories(
   pr: PullRequest,
   stalePRDays: number,
   longWaitDays: number,
+  stackBlocked = false,
 ): Set<UrgencyCategory> {
   const categories = new Set<UrgencyCategory>();
 
@@ -23,6 +24,7 @@ export function getUrgencyCategories(
   if (pr.unresolvedCommentCount > 0) categories.add('unresolved_comments');
   if (pr.isReviewRequested && !pr.hasReviewed) categories.add('review_requested');
   if (pr.hasConflicts) categories.add('conflicts');
+  if (stackBlocked) categories.add('stack_blocked');
 
   const isLongWait =
     longWaitDays > 0 &&
@@ -38,8 +40,9 @@ export function matchesUrgencyFilter(
   filter: UrgencyCategory,
   stalePRDays: number,
   longWaitDays: number,
+  stackBlocked = false,
 ): boolean {
-  return getUrgencyCategories(pr, stalePRDays, longWaitDays).has(filter);
+  return getUrgencyCategories(pr, stalePRDays, longWaitDays, stackBlocked).has(filter);
 }
 
 const CATEGORY_ORDER: UrgencyCategory[] = [
@@ -48,6 +51,7 @@ const CATEGORY_ORDER: UrgencyCategory[] = [
   'unresolved_comments',
   'review_requested',
   'conflicts',
+  'stack_blocked',
   'stale',
   'long_wait',
 ];
@@ -56,13 +60,14 @@ export function computeUrgencyCounts(
   prs: PullRequest[],
   stalePRDays: number,
   longWaitDays: number,
+  blockedIds?: Set<string>,
 ): Map<UrgencyCategory, number> {
   const counts = new Map<UrgencyCategory, number>(
     CATEGORY_ORDER.map((c) => [c, 0]),
   );
 
   for (const pr of prs) {
-    const cats = getUrgencyCategories(pr, stalePRDays, longWaitDays);
+    const cats = getUrgencyCategories(pr, stalePRDays, longWaitDays, blockedIds?.has(pr.id));
     for (const cat of cats) {
       counts.set(cat, (counts.get(cat) ?? 0) + 1);
     }
@@ -116,5 +121,11 @@ export const URGENCY_META: Record<
     icon: '\u{1F550}',
     colorClasses: 'bg-orange-50 dark:bg-orange-900/10 text-orange-600 dark:text-orange-400 border-orange-200 dark:border-orange-800/20',
     activeColorClasses: 'bg-orange-100 dark:bg-orange-900/25 text-orange-700 dark:text-orange-300 border-orange-300 dark:border-orange-500/50 ring-1 ring-orange-300/30 dark:ring-orange-500/15',
+  },
+  stack_blocked: {
+    label: 'Stack blocked',
+    icon: '\u{1F95E}',
+    colorClasses: 'bg-indigo-50 dark:bg-indigo-900/10 text-indigo-600 dark:text-indigo-400 border-indigo-200 dark:border-indigo-800/20',
+    activeColorClasses: 'bg-indigo-100 dark:bg-indigo-900/25 text-indigo-700 dark:text-indigo-300 border-indigo-300 dark:border-indigo-500/50 ring-1 ring-indigo-300/30 dark:ring-indigo-500/15',
   },
 };

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -225,6 +225,8 @@ async function hydratePR(
     hasReviewed,
     pendingReviewers: pendingReviewers.length > 0 ? pendingReviewers : undefined,
     headSha: pr.source.commit?.hash,
+    headRef: pr.source.branch.name,
+    baseBranch: pr.destination.branch.name,
   };
 }
 

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -133,7 +133,7 @@ interface GHPullRequest {
   created_at: string;
   updated_at: string;
   head: { sha: string; ref: string; repo: { full_name: string } | null };
-  base: { repo: { full_name: string } };
+  base: { ref: string; repo: { full_name: string } };
   mergeable_state?: string;
   requested_reviewers?: GHUser[];
 }
@@ -339,6 +339,7 @@ async function hydratePR(
     pendingReviewers: pendingReviewers.length > 0 ? pendingReviewers : undefined,
     headSha: pr.head.sha,
     headRef: pr.head.ref,
+    baseBranch: pr.base.ref,
     deployment,
   };
 }

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -63,6 +63,7 @@ interface GLMergeRequest {
   created_at: string;
   updated_at: string;
   source_branch: string;
+  target_branch: string;
   sha: string;
   has_conflicts: boolean;
   reviewers?: GLUser[];
@@ -249,6 +250,8 @@ async function hydrateMR(
     hasReviewed,
     pendingReviewers: pendingReviewers.length > 0 ? pendingReviewers : undefined,
     headSha: mr.sha,
+    headRef: mr.source_branch,
+    baseBranch: mr.target_branch,
     deployment,
   };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -53,6 +53,7 @@ export interface PullRequest {
   mergedAt?: number;
   headSha?: string;
   headRef?: string;
+  baseBranch?: string;
   deployment?: {
     environment: string;
     status: 'success' | 'failure' | 'pending' | 'inactive';
@@ -143,7 +144,8 @@ export type UrgencyCategory =
   | 'review_requested'
   | 'conflicts'
   | 'stale'
-  | 'long_wait';
+  | 'long_wait'
+  | 'stack_blocked';
 
 export type SortMode = 'default' | 'recent' | 'oldest';
 


### PR DESCRIPTION
## Summary

- Detect stacked PRs by matching each PR's base branch against open PRs' head branches (within the same repo + platform). Works on GitHub, GitLab, and Bitbucket.
- Group stack members together in default sort mode with parents above children, indent children with an indigo accent bar, and show a 🥞 N/M position chip whose tooltip carries parent context.
- New \`stack_blocked\` urgency category lights up the triage chip bar when a PR is waiting on an unmerged parent.

## Test plan

- [ ] Open a 2+ PR stack on GitHub; verify children indent, position chip shows correct N/M, and triage bar lights up "Stack blocked"
- [ ] Test on GitLab and Bitbucket with stacked MRs/PRs
- [ ] Switch to "Recent" / "Oldest" sort — stack grouping should disable (flat chronological list)
- [ ] Activate the "Long wait" urgency filter — stack grouping should also disable
- [ ] Merge the parent PR — child should no longer show stack-blocked after next poll
- [ ] PRs not in a stack should look unchanged (no accent bar, no chip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detect and group related PRs (stacks) so members render contiguously.
  * Position badges show "position/total" with contextual "based on/waiting on" when applicable.
  * Visual indentation and colored left border emphasize PR dependency chains.
  * New "stack blocked" urgency category surfaces PRs awaiting parent merges; counts and filters reflect this.

* **Documentation**
  * Updated docs to describe stacked-PR behavior and the "Stack blocked" urgency chip.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deployhq/pr-radar/pull/13)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->