### PR TITLE
Bump version to 0.5.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "PR Radar – GitHub, GitLab & Bitbucket PRs",
   "description": "Track PRs, CI status, code reviews & deployments across GitHub, GitLab and Bitbucket. No backend, free forever. By DeployHQ.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-radar",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Track PRs, CI status, code reviews & deployments across GitHub, GitLab and Bitbucket. No backend, free forever. By DeployHQ.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Patch release.

Fixes incorrect stack chip (e.g. 🥞 1/18) on PRs targeting long-lived integration branches like \`staging\`, \`develop\`, \`release/*\` (#15).

Merging + tagging \`v0.5.1\` will trigger Chrome / Firefox / Edge publish workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.5.1

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deployhq/pr-radar/pull/16)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->