### PR TITLE
Detect team-based review requests + macOS notification hint

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -276,10 +276,17 @@ async function pollPRs() {
     for (const account of accounts) {
       const repos = enabledRepos.filter((r) => r.platform === account.platform);
 
+      // Fetch user's GitHub teams once per poll so we can detect team-based
+      // review requests (CODEOWNERS, team assignments) — PR API's
+      // requested_reviewers only lists individual users.
+      const githubTeams = account.platform === 'github'
+        ? await github.getUserTeams(account.token).catch(() => [])
+        : [];
+
       for (const repo of repos) {
         try {
           if (account.platform === 'github') {
-            const prs = await github.fetchPullRequests(account.token, repo.fullName, account.username);
+            const prs = await github.fetchPullRequests(account.token, repo.fullName, account.username, githubTeams);
             allPRs.push(...prs);
           } else if (account.platform === 'gitlab') {
             const prs = await gitlab.fetchMergeRequests(account.token, repo.fullName, account.username);

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -150,6 +150,12 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
             Test
           </button>
         </SettingRow>
+        {isMacOS() && (
+          <div className="mt-1 px-3 py-2 rounded-md bg-amber-50 dark:bg-amber-900/15 border border-amber-200 dark:border-amber-800/40 text-[11px] text-amber-800 dark:text-amber-300 leading-relaxed">
+            <strong>macOS:</strong> if the test plays a sound but you don&apos;t see a popup, open{' '}
+            <em>System Settings &rsaquo; Notifications &rsaquo; Google Chrome</em> and make sure notifications are allowed with an alert style of <em>Banner</em> or <em>Alert</em> (not <em>None</em>). Also check that <em>Focus / Do Not Disturb</em> is off.
+          </div>
+        )}
       </Section>
 
       {/* Appearance */}
@@ -481,6 +487,11 @@ function SettingRow({
   );
 }
 
+
+function isMacOS(): boolean {
+  if (typeof navigator === 'undefined') return false;
+  return /Mac/i.test(navigator.userAgent);
+}
 
 function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: boolean) => void; label?: string }) {
   return (

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -136,6 +136,12 @@ interface GHPullRequest {
   base: { ref: string; repo: { full_name: string } };
   mergeable_state?: string;
   requested_reviewers?: GHUser[];
+  requested_teams?: { slug: string; name: string }[];
+}
+
+export interface GHUserTeam {
+  org: string;
+  slug: string;
 }
 
 export interface GHReview {
@@ -146,6 +152,21 @@ export interface GHReview {
 
 export async function getAuthenticatedUser(token: string): Promise<{ login: string; avatar_url: string }> {
   return ghFetch('/user', token);
+}
+
+// Teams the authenticated user is a member of. Used to detect team-based review
+// requests (CODEOWNERS, team assignments) — GitHub's PR API only populates
+// requested_reviewers with individual users; team members aren't included there.
+export async function getUserTeams(token: string): Promise<GHUserTeam[]> {
+  try {
+    const teams = await ghPaginate<{ slug: string; organization: { login: string } }>(
+      '/user/teams?per_page=100',
+      token,
+    );
+    return teams.map((t) => ({ org: t.organization.login, slug: t.slug }));
+  } catch {
+    return [];
+  }
 }
 
 export async function getUserRepos(token: string): Promise<{ full_name: string }[]> {
@@ -262,16 +283,24 @@ export async function fetchPullRequests(
   token: string,
   repoFullName: string,
   username: string,
+  userTeams: GHUserTeam[] = [],
 ): Promise<PullRequest[]> {
   const prs = await ghPaginate<GHPullRequest>(
     `/repos/${repoFullName}/pulls?state=open&per_page=100`,
     token,
   );
 
+  // A team-based review request only applies if the team is in the repo's owner
+  // org. Pre-filter to the relevant teams once per repo.
+  const repoOrg = repoFullName.split('/')[0];
+  const relevantTeamSlugs = new Set(
+    userTeams.filter((t) => t.org.toLowerCase() === repoOrg.toLowerCase()).map((t) => t.slug),
+  );
+
   const results = await mapWithConcurrencyLimit(
     prs,
     HYDRATE_CONCURRENCY,
-    (pr) => hydratePR(token, repoFullName, pr, username),
+    (pr) => hydratePR(token, repoFullName, pr, username, relevantTeamSlugs),
   );
 
   return results;
@@ -282,6 +311,7 @@ async function hydratePR(
   repoFullName: string,
   pr: GHPullRequest,
   username: string,
+  relevantTeamSlugs: Set<string>,
 ): Promise<PullRequest> {
   // Fetch CI status, reviews, unresolved threads, and deployments in parallel
   const [ciResult, reviews, graphqlDetails, deployment] = await Promise.all([
@@ -301,7 +331,12 @@ async function hydratePR(
       .filter((r) => !pr.head?.sha || r.commit_id === pr.head.sha)
       .map((r) => r.user.login),
   )];
-  const isReviewRequested = pr.requested_reviewers?.some((r) => r.login === username) ?? false;
+  // Review can be requested directly (requested_reviewers) or via a team the
+  // user belongs to (requested_teams). The PR API doesn't expand team members
+  // into requested_reviewers, so check both.
+  const isReviewRequestedDirectly = pr.requested_reviewers?.some((r) => r.login === username) ?? false;
+  const isReviewRequestedViaTeam = pr.requested_teams?.some((t) => relevantTeamSlugs.has(t.slug)) ?? false;
+  const isReviewRequested = isReviewRequestedDirectly || isReviewRequestedViaTeam;
   const pendingReviewers = pr.requested_reviewers?.map((r) => r.login) ?? [];
   const hasReviewed = checkHasReviewed(reviews, username, pr.head.sha);
 


### PR DESCRIPTION
## Summary

Two fixes prompted by a customer report (Review tab empty despite being tagged; macOS notifications sound but no popup):

**Bug 1 — Review tab empty for team-tagged reviewers (real code bug).** GitHub's PR API only populates \`requested_reviewers\` with individual users. The most common assignment in practice is via team requests (CODEOWNERS, team-based ownership), which lands in \`requested_teams\` — team members aren't expanded into \`requested_reviewers\`.

Fix:
- New \`getUserTeams()\` fetches \`/user/teams\` once per poll, returning \`{ org, slug }[]\`
- \`fetchPullRequests\` accepts the team list, pre-filters to teams in the repo's owner org
- \`hydratePR\` ORs the existing user-based check with \`requested_teams\` membership

Requires \`read:org\` scope (already required for org repo discovery — no scope change).

**Bug 2 — macOS notifications: sound plays, popup invisible (OS-level).** \`chrome.notifications.create\` is being called correctly; macOS is suppressing the banner via either System Settings permission or Focus mode. Added a macOS-only callout under the Test button explaining the exact System Settings path and the Focus check.

## Test plan

- [ ] On a GitHub repo where you're requested via a team (e.g. CODEOWNERS team request), Review tab now shows the PR
- [ ] Direct individual review requests still work
- [ ] User with no team memberships: Review tab unchanged
- [ ] On macOS, open Settings — amber callout under the Test button appears with the System Settings instructions
- [ ] On Windows/Linux, callout does not appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review requests now detected from GitHub team assignments in addition to direct user assignments.
  * Added macOS-specific guidance in Settings for notification troubleshooting, including Chrome notification style configuration and Focus/Do Not Disturb management.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/deployhq/pr-radar/pull/17)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->