### PR TITLE
feat: on-device AI summaries for PRs and review threads

### DIFF
--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -1,6 +1,6 @@
 import type { PullRequest, CIStatus, Message, PollError, PollErrorKind, Platform, RateLimitInfo } from '@/shared/types';
 import { CI_STATUS_LABELS } from '@/shared/constants';
-import { getSettings, getAccounts, getWatchedRepos, getCachedPRs, saveCachedPRs, setInstallDate, getDeployHQAccount, saveDeployHQAccount, getDeployHQRepoMapping, saveDeployHQRepoMapping, savePollErrors, saveRateLimits, getRateLimits, saveAccount } from '@/shared/storage';
+import { getSettings, getAccounts, getWatchedRepos, getCachedPRs, saveCachedPRs, setInstallDate, getDeployHQAccount, saveDeployHQAccount, getDeployHQRepoMapping, saveDeployHQRepoMapping, savePollErrors, saveRateLimits, getRateLimits, saveAccount, setWhatsNewSeenVersion } from '@/shared/storage';
 import * as github from '@/shared/api/github';
 import * as gitlab from '@/shared/api/gitlab';
 import * as bitbucket from '@/shared/api/bitbucket';
@@ -63,9 +63,14 @@ async function saveLastCommentCounts(counts: Record<string, number>): Promise<vo
 
 // === Lifecycle ===
 
-chrome.runtime.onInstalled.addListener(() => {
+chrome.runtime.onInstalled.addListener((details) => {
   setInstallDate();
   setupPolling();
+  // Suppress the "what's new" banner for brand-new users — only people who
+  // *update* into a release should see it.
+  if (details.reason === 'install') {
+    setWhatsNewSeenVersion(chrome.runtime.getManifest().version);
+  }
 });
 
 chrome.alarms.onAlarm.addListener((alarm) => {

--- a/src/background/service-worker.ts
+++ b/src/background/service-worker.ts
@@ -200,6 +200,30 @@ chrome.runtime.onMessage.addListener((message: Message, _sender, sendResponse) =
       if (result.success) pollPRs();
     })();
     return true;
+  } else if (message.type === 'GET_PR_THREADS') {
+    const { platform, repoFullName, prNumber } = message.payload;
+    (async () => {
+      const accounts = await getAccounts();
+      const account = accounts.find((a) => a.platform === platform);
+      if (!account) {
+        sendResponse({ success: false, threads: [], message: 'Account not found' });
+        return;
+      }
+      try {
+        let threads;
+        if (platform === 'github') {
+          threads = await github.fetchUnresolvedThreads(account.token, repoFullName, prNumber);
+        } else if (platform === 'gitlab') {
+          threads = await gitlab.fetchUnresolvedThreads(account.token, repoFullName, prNumber);
+        } else {
+          threads = await bitbucket.fetchUnresolvedThreads(account.token, repoFullName, prNumber);
+        }
+        sendResponse({ success: true, threads });
+      } catch (err) {
+        sendResponse({ success: false, threads: [], message: err instanceof Error ? err.message : 'Failed to fetch threads' });
+      }
+    })();
+    return true;
   }
 });
 

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react';
-import type { PullRequest, Message, DeployHQServer } from '@/shared/types';
+import { useState, useEffect } from 'react';
+import type { PullRequest, Message, DeployHQServer, UnresolvedThread } from '@/shared/types';
 import type { StackInfo } from '../utils/stacks';
+import { isSummarizerSupported, getCachedSummary, generateSummary, summaryCacheKey, generateThreadSummary, threadSummaryCacheKey } from '@/shared/ai/summarizer';
 import CIBadge from './CIBadge';
 import PlatformIcon from './PlatformIcon';
 
@@ -13,9 +14,10 @@ interface PRItemProps {
   stackInfo?: StackInfo;
   parentUnmerged?: boolean;
   parentNumber?: number;
+  aiEnabled?: boolean;
 }
 
-export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, stackInfo, parentUnmerged, parentNumber }: PRItemProps) {
+export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, stackInfo, parentUnmerged, parentNumber, aiEnabled }: PRItemProps) {
   const [mergeState, setMergeState] = useState<'idle' | 'confirm' | 'merging' | 'merged' | 'error'>('idle');
   const [mergeError, setMergeError] = useState('');
   const [branchState, setBranchState] = useState<'idle' | 'confirm' | 'deleting' | 'deleted' | 'error'>('idle');
@@ -25,7 +27,85 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
   const [servers, setServers] = useState<DeployHQServer[]>([]);
   const [selectedServer, setSelectedServer] = useState('');
   const [expanded, setExpanded] = useState(false);
+  const [summary, setSummary] = useState<string | null>(null);
+  const [summaryState, setSummaryState] = useState<'idle' | 'loading' | 'done' | 'error'>('idle');
+  const [threadsExpanded, setThreadsExpanded] = useState(false);
+  const [threadSummary, setThreadSummary] = useState<string | null>(null);
+  const [threadState, setThreadState] = useState<'idle' | 'loading' | 'done' | 'error' | 'empty'>('idle');
   const description = pr.description?.trim();
+  const aiAvailable = Boolean(aiEnabled) && isSummarizerSupported();
+  const tldrEnabled = aiAvailable && Boolean(description);
+  const threadsAvailable = aiAvailable && pr.unresolvedCommentCount > 0;
+
+  async function toggleThreads() {
+    const next = !threadsExpanded;
+    setThreadsExpanded(next);
+    // Only fetch+summarize on first open; later toggles just show/hide.
+    if (!next || threadSummary || threadState === 'loading') return;
+
+    const cacheKey = threadSummaryCacheKey(pr);
+    const cached = await getCachedSummary(cacheKey);
+    if (cached) {
+      setThreadSummary(cached);
+      setThreadState('done');
+      return;
+    }
+
+    setThreadState('loading');
+    try {
+      const msg: Message = { type: 'GET_PR_THREADS', payload: { platform: pr.platform, repoFullName: pr.repoFullName, prNumber: pr.number } };
+      const res = await chrome.runtime.sendMessage(msg) as { success: boolean; threads: UnresolvedThread[]; message?: string };
+      if (!res.success || !res.threads?.length) {
+        setThreadState('empty');
+        return;
+      }
+      const result = await generateThreadSummary(cacheKey, res.threads);
+      if (result) {
+        setThreadSummary(result);
+        setThreadState('done');
+      } else {
+        setThreadState('empty');
+      }
+    } catch {
+      setThreadState('error');
+    }
+  }
+
+  // Fetch the on-device TL;DR, cache-first. Effect re-runs when the PR or its
+  // head SHA changes so a new push refreshes the summary. Degrades silently:
+  // on any failure the line simply doesn't render.
+  useEffect(() => {
+    if (!tldrEnabled) {
+      setSummary(null);
+      setSummaryState('idle');
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      const cached = await getCachedSummary(summaryCacheKey(pr));
+      if (cancelled) return;
+      if (cached) {
+        setSummary(cached);
+        setSummaryState('done');
+        return;
+      }
+      setSummaryState('loading');
+      try {
+        const result = await generateSummary(pr);
+        if (cancelled) return;
+        if (result) {
+          setSummary(result);
+          setSummaryState('done');
+        } else {
+          setSummaryState('idle');
+        }
+      } catch {
+        if (!cancelled) setSummaryState('error');
+      }
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tldrEnabled, pr.id, pr.headSha]);
   const timeAgo = getTimeAgo(pr.updatedAt);
   const isStale = stalePRDays > 0 && (Date.now() - new Date(pr.updatedAt).getTime()) > stalePRDays * 86400000;
   const isDimmed = (pr.hasReviewed && !pr.isAuthor) || isStale || pr.isBot || pr.isMerged || pr.isDraft;
@@ -370,12 +450,26 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
           )}
 
           {pr.unresolvedCommentCount > 0 && (
-            <span title={pr.unresolvedCommentAuthors ? `Unresolved from: ${pr.unresolvedCommentAuthors.join(', ')}` : undefined}
-              aria-label={`${pr.unresolvedCommentCount} unresolved comment${pr.unresolvedCommentCount > 1 ? 's' : ''}${pr.unresolvedCommentAuthors ? ` from ${pr.unresolvedCommentAuthors.join(', ')}` : ''}`}>
-              <Badge className="bg-amber-50 dark:bg-gray-800 text-amber-600 dark:text-amber-400">
-                <span aria-hidden="true">&#x1F4AC;</span> {pr.unresolvedCommentCount}
-              </Badge>
-            </span>
+            threadsAvailable ? (
+              <button
+                onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleThreads(); }}
+                aria-expanded={threadsExpanded}
+                title={pr.unresolvedCommentAuthors ? `Unresolved from: ${pr.unresolvedCommentAuthors.join(', ')} — click to summarize` : 'Click to summarize unresolved threads'}
+                aria-label={`${pr.unresolvedCommentCount} unresolved comment${pr.unresolvedCommentCount > 1 ? 's' : ''}, click to summarize`}
+              >
+                <Badge className="bg-amber-50 dark:bg-gray-800 text-amber-600 dark:text-amber-400 cursor-pointer hover:bg-amber-100 dark:hover:bg-gray-700 transition-colors">
+                  <span aria-hidden="true">&#x1F4AC;</span> {pr.unresolvedCommentCount}
+                  <span aria-hidden="true" className="text-[8px] ml-0.5">{threadsExpanded ? '▴' : '▾'}</span>
+                </Badge>
+              </button>
+            ) : (
+              <span title={pr.unresolvedCommentAuthors ? `Unresolved from: ${pr.unresolvedCommentAuthors.join(', ')}` : undefined}
+                aria-label={`${pr.unresolvedCommentCount} unresolved comment${pr.unresolvedCommentCount > 1 ? 's' : ''}${pr.unresolvedCommentAuthors ? ` from ${pr.unresolvedCommentAuthors.join(', ')}` : ''}`}>
+                <Badge className="bg-amber-50 dark:bg-gray-800 text-amber-600 dark:text-amber-400">
+                  <span aria-hidden="true">&#x1F4AC;</span> {pr.unresolvedCommentCount}
+                </Badge>
+              </span>
+            )
           )}
 
           {pr.pendingReviewers && pr.pendingReviewers.length > 0 && (
@@ -463,6 +557,51 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
         )}
       </a>
 
+      {tldrEnabled && (summaryState === 'loading' || (summaryState === 'done' && summary)) && (
+        <div className="ml-[30px] mt-1 flex items-start gap-1 text-[11px] leading-snug">
+          <span aria-hidden="true" className="mt-px text-radar-400">{'✨'}</span>
+          {summaryState === 'loading' ? (
+            <span className="text-gray-400 dark:text-gray-500 italic" role="status" aria-label="Summarizing pull request">
+              Summarizing&hellip;
+            </span>
+          ) : (
+            <span className="flex-1 min-w-0 text-gray-600 dark:text-gray-400 break-words line-clamp-2" title={summary ?? undefined}>
+              <span className="sr-only">AI summary: </span>{summary}
+            </span>
+          )}
+        </div>
+      )}
+
+      {threadsExpanded && (
+        <div className="ml-[30px] mt-1 rounded-md bg-amber-50/50 dark:bg-gray-800/40 border border-amber-100 dark:border-gray-700/50 px-2.5 py-1.5">
+          {threadState === 'loading' && (
+            <div className="flex items-center gap-1.5 text-[11px] text-gray-400 dark:text-gray-500 italic" role="status" aria-label="Summarizing unresolved threads">
+              <span className="inline-block w-2.5 h-2.5 border-[1.5px] border-gray-400/30 border-t-gray-400 rounded-full animate-spin" />
+              Reading threads&hellip;
+            </div>
+          )}
+          {threadState === 'done' && threadSummary && (
+            <div className="text-[11px]">
+              <div className="flex items-center gap-1 text-gray-500 dark:text-gray-400 font-medium mb-1">
+                <span aria-hidden="true" className="text-radar-400">{'✨'}</span>
+                {pr.unresolvedCommentCount} unresolved {pr.unresolvedCommentCount === 1 ? 'thread' : 'threads'}
+              </div>
+              <ul className="list-disc pl-4 space-y-0.5 text-gray-600 dark:text-gray-400">
+                {toBullets(threadSummary).map((bullet, i) => (
+                  <li key={i} className="break-words">{bullet}</li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {threadState === 'empty' && (
+            <div className="text-[11px] text-gray-400 dark:text-gray-500 italic">Nothing to summarize.</div>
+          )}
+          {threadState === 'error' && (
+            <div className="text-[11px] text-gray-400 dark:text-gray-500 italic">Couldn&apos;t summarize threads.</div>
+          )}
+        </div>
+      )}
+
       {description && (
         <div className="ml-[30px] mt-1">
           <button
@@ -490,6 +629,16 @@ function Badge({ children, className }: { children: React.ReactNode; className: 
       {children}
     </span>
   );
+}
+
+// Split the model's key-points output (markdown bullets, or a plain paragraph
+// if it didn't bullet) into clean list items.
+function toBullets(text: string): string[] {
+  const lines = text
+    .split('\n')
+    .map((line) => line.replace(/^\s*[-*•]\s*/, '').trim())
+    .filter(Boolean);
+  return lines.length > 0 ? lines : [text.trim()];
 }
 
 function getTimeAgo(dateStr: string): string {

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { PullRequest, Message, DeployHQServer, UnresolvedThread } from '@/shared/types';
 import type { StackInfo } from '../utils/stacks';
-import { isSummarizerSupported, getCachedSummary, generateSummary, summaryCacheKey, generateThreadSummary, threadSummaryCacheKey } from '@/shared/ai/summarizer';
+import { isSummarizerSupported, getCachedSummary, generateSummary, summaryCacheKey, generateThreadSummary, threadSummaryCacheKey, prewarmThreadSummary } from '@/shared/ai/summarizer';
 import CIBadge from './CIBadge';
 import PlatformIcon from './PlatformIcon';
 
@@ -42,6 +42,10 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
     setThreadsExpanded(next);
     // Only fetch+summarize on first open; later toggles just show/hide.
     if (!next || threadSummary || threadState === 'loading') return;
+
+    // Prewarm synchronously under this click gesture — create() must run during
+    // the activation, before we await the thread fetch below.
+    prewarmThreadSummary();
 
     const cacheKey = threadSummaryCacheKey(pr);
     const cached = await getCachedSummary(cacheKey);

--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -109,7 +109,16 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tldrEnabled, pr.id, pr.headSha]);
+  }, [tldrEnabled, pr.id, pr.headSha, description]);
+
+  // Reset the thread digest when the PR identity changes (a new push, or a
+  // change in unresolved count). Dashboard reuses the row component by pr.id,
+  // so without this a stale digest could persist across updates.
+  useEffect(() => {
+    setThreadsExpanded(false);
+    setThreadSummary(null);
+    setThreadState('idle');
+  }, [pr.id, pr.headSha, pr.unresolvedCommentCount]);
   const timeAgo = getTimeAgo(pr.updatedAt);
   const isStale = stalePRDays > 0 && (Date.now() - new Date(pr.updatedAt).getTime()) > stalePRDays * 86400000;
   const isDimmed = (pr.hasReviewed && !pr.isAuthor) || isStale || pr.isBot || pr.isMerged || pr.isDraft;
@@ -458,6 +467,7 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
               <button
                 onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleThreads(); }}
                 aria-expanded={threadsExpanded}
+                aria-controls={`thread-summary-${pr.id}`}
                 title={pr.unresolvedCommentAuthors ? `Unresolved from: ${pr.unresolvedCommentAuthors.join(', ')} — click to summarize` : 'Click to summarize unresolved threads'}
                 aria-label={`${pr.unresolvedCommentCount} unresolved comment${pr.unresolvedCommentCount > 1 ? 's' : ''}, click to summarize`}
               >
@@ -577,10 +587,14 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
       )}
 
       {threadsExpanded && (
-        <div className="ml-[30px] mt-1 rounded-md bg-amber-50/50 dark:bg-gray-800/40 border border-amber-100 dark:border-gray-700/50 px-2.5 py-1.5">
+        <div
+          id={`thread-summary-${pr.id}`}
+          aria-live="polite"
+          className="ml-[30px] mt-1 rounded-md bg-amber-50/50 dark:bg-gray-800/40 border border-amber-100 dark:border-gray-700/50 px-2.5 py-1.5"
+        >
           {threadState === 'loading' && (
             <div className="flex items-center gap-1.5 text-[11px] text-gray-400 dark:text-gray-500 italic" role="status" aria-label="Summarizing unresolved threads">
-              <span className="inline-block w-2.5 h-2.5 border-[1.5px] border-gray-400/30 border-t-gray-400 rounded-full animate-spin" />
+              <span aria-hidden="true" className="inline-block w-2.5 h-2.5 border-[1.5px] border-gray-400/30 border-t-gray-400 rounded-full animate-spin" />
               Reading threads&hellip;
             </div>
           )}

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -30,6 +30,7 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
   const [pinnedRepos, setPinnedRepos] = useState<Set<string>>(new Set());
   const [stalePRDays, setStalePRDays] = useState(45);
   const [longWaitDays, setLongWaitDays] = useState(2);
+  const [aiEnabled, setAiEnabled] = useState(false);
   const [lastUpdated, setLastUpdated] = useState<number | null>(null);
   const [urgencyFilter, setUrgencyFilter] = useState<UrgencyCategory | null>(null);
   const [sortMode, setSortMode] = useState<SortMode>('default');
@@ -81,6 +82,7 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
       setStalePRDays(settings.stalePRDays);
       setLongWaitDays(settings.longWaitDays);
       setSortMode(settings.sortMode);
+      setAiEnabled(settings.aiEnabled);
 
       const hadCache = await loadFromCache();
       setLoading(false);
@@ -501,6 +503,7 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
                   stackInfo={stackInfo}
                   parentUnmerged={blockedIds.has(pr.id)}
                   parentNumber={parentPr?.number}
+                  aiEnabled={aiEnabled}
                 />
               );
             })}

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -415,7 +415,11 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
 
       {/* What's-new banner — version-gated, shown to users who updated in */}
       {showWhatsNew && (
-        <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-radar-200 dark:border-radar-900/50 bg-radar-50 dark:bg-radar-950/30">
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center justify-between gap-2 px-4 py-2 border-b border-radar-200 dark:border-radar-900/50 bg-radar-50 dark:bg-radar-950/30"
+        >
           <button
             onClick={() => { dismissWhatsNew(); onNavigate({ type: 'settings' }); }}
             className="text-left text-[11px] text-gray-500 dark:text-gray-400 hover:text-radar-600 dark:hover:text-radar-400 transition-colors"

--- a/src/popup/pages/Dashboard.tsx
+++ b/src/popup/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import type { AppView, DashboardTab, PullRequest, SortMode, UrgencyCategory } from '@/shared/types';
-import { getWatchedRepos, getCachedPRs, getSettings, saveSettings, getInstallDate, isStarPromptDismissed, dismissStarPrompt } from '@/shared/storage';
+import { getWatchedRepos, getCachedPRs, getSettings, saveSettings, getInstallDate, isStarPromptDismissed, dismissStarPrompt, getWhatsNewSeenVersion, setWhatsNewSeenVersion } from '@/shared/storage';
 import { STORE_URL, GITHUB_REPO_URL } from '@/shared/constants';
 import { matchesUrgencyFilter, computeUrgencyCounts } from '../utils/urgency';
 import { detectStacks, isStackBlocked } from '../utils/stacks';
@@ -35,6 +35,7 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
   const [urgencyFilter, setUrgencyFilter] = useState<UrgencyCategory | null>(null);
   const [sortMode, setSortMode] = useState<SortMode>('default');
   const [showStarBanner, setShowStarBanner] = useState(false);
+  const [showWhatsNew, setShowWhatsNew] = useState(false);
   const [focusedIndex, setFocusedIndex] = useState(-1);
   const [showShortcuts, setShowShortcuts] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -137,6 +138,23 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
     }
     checkStarBanner();
   }, []);
+
+  // Show the "what's new" banner to users who updated into a new release and
+  // haven't acknowledged it. Fresh installs are stamped on install, so they're
+  // excluded; the installDate guard also avoids a flash before install setup.
+  useEffect(() => {
+    async function checkWhatsNew() {
+      const [seenVersion, installDate] = await Promise.all([getWhatsNewSeenVersion(), getInstallDate()]);
+      const currentVersion = chrome.runtime.getManifest().version;
+      if (installDate && seenVersion !== currentVersion) setShowWhatsNew(true);
+    }
+    checkWhatsNew();
+  }, []);
+
+  function dismissWhatsNew() {
+    setShowWhatsNew(false);
+    setWhatsNewSeenVersion(chrome.runtime.getManifest().version);
+  }
 
   // Reset urgency filter on tab change and persist the active tab
   useEffect(() => {
@@ -394,6 +412,26 @@ export default function Dashboard({ tab, onNavigate }: DashboardProps) {
           </span>
         ) : null}
       </div>
+
+      {/* What's-new banner — version-gated, shown to users who updated in */}
+      {showWhatsNew && (
+        <div className="flex items-center justify-between gap-2 px-4 py-2 border-b border-radar-200 dark:border-radar-900/50 bg-radar-50 dark:bg-radar-950/30">
+          <button
+            onClick={() => { dismissWhatsNew(); onNavigate({ type: 'settings' }); }}
+            className="text-left text-[11px] text-gray-500 dark:text-gray-400 hover:text-radar-600 dark:hover:text-radar-400 transition-colors"
+          >
+            <span aria-hidden="true">{'✨'}</span> New: AI summaries — <span className="text-radar-400">turn on in Settings &rsaquo;</span>
+          </button>
+          <button
+            onClick={dismissWhatsNew}
+            className="text-gray-400 dark:text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 text-xs leading-none flex-shrink-0"
+            title="Dismiss"
+            aria-label="Dismiss what's new banner"
+          >
+            &#10005;
+          </button>
+        </div>
+      )}
 
       {/* Star banner */}
       {showStarBanner && (

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -3,7 +3,7 @@ import type { AppView, Platform, DeployHQAccount } from '@/shared/types';
 import { PLATFORM_LABELS, SOUND_OPTIONS } from '@/shared/constants';
 import { getSettings, saveSettings, getAccounts, removeAccount, getDeployHQAccount, removeDeployHQAccount, type Settings as SettingsType, type ThemeMode } from '@/shared/storage';
 import { STORE_URL, GITHUB_REPO_URL, GITHUB_ISSUES_URL } from '@/shared/constants';
-import { isSummarizerSupported } from '@/shared/ai/summarizer';
+import { isSummarizerSupported, summarizerAvailability, prewarmSummary, prewarmThreadSummary } from '@/shared/ai/summarizer';
 
 interface SettingsProps {
   onNavigate: (view: AppView) => void;
@@ -14,7 +14,17 @@ interface SettingsProps {
 export default function Settings({ onNavigate, theme, onThemeChange }: SettingsProps) {
   const [settings, setSettings] = useState<SettingsType | null>(null);
   const [connectedPlatforms, setConnectedPlatforms] = useState<{ platform: Platform; username: string }[]>([]);
-  const aiSupported = isSummarizerSupported();
+  // Show the AI section only where the API exists AND the on-device model can
+  // actually run — `unavailable` means the hardware/storage gate failed, so
+  // enabling it would just no-op. `downloadable`/`available` both qualify.
+  const [aiSupported, setAiSupported] = useState(false);
+
+  useEffect(() => {
+    if (!isSummarizerSupported()) return;
+    summarizerAvailability()
+      .then((availability) => setAiSupported(availability !== 'unavailable'))
+      .catch(() => setAiSupported(false));
+  }, []);
 
   // DeployHQ state
   const [dhqAccount, setDhqAccount] = useState<DeployHQAccount | null>(null);
@@ -234,7 +244,16 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
             label="Enable AI features"
             description="Adds a short TL;DR under each PR and a digest of unresolved review threads. Runs locally in Chrome — nothing leaves your browser. Downloads a model on first use."
           >
-            <Toggle checked={settings.aiEnabled} onChange={(v) => handleToggle('aiEnabled', v)} label="Enable AI features" />
+            <Toggle
+              checked={settings.aiEnabled}
+              onChange={(v) => {
+                // Prewarm under this user gesture so the first model download is
+                // activation-bound (Chrome requires it for Summarizer.create()).
+                if (v) { prewarmSummary(); prewarmThreadSummary(); }
+                handleToggle('aiEnabled', v);
+              }}
+              label="Enable AI features"
+            />
           </SettingRow>
         </Section>
       )}

--- a/src/popup/pages/Settings.tsx
+++ b/src/popup/pages/Settings.tsx
@@ -3,6 +3,7 @@ import type { AppView, Platform, DeployHQAccount } from '@/shared/types';
 import { PLATFORM_LABELS, SOUND_OPTIONS } from '@/shared/constants';
 import { getSettings, saveSettings, getAccounts, removeAccount, getDeployHQAccount, removeDeployHQAccount, type Settings as SettingsType, type ThemeMode } from '@/shared/storage';
 import { STORE_URL, GITHUB_REPO_URL, GITHUB_ISSUES_URL } from '@/shared/constants';
+import { isSummarizerSupported } from '@/shared/ai/summarizer';
 
 interface SettingsProps {
   onNavigate: (view: AppView) => void;
@@ -13,6 +14,7 @@ interface SettingsProps {
 export default function Settings({ onNavigate, theme, onThemeChange }: SettingsProps) {
   const [settings, setSettings] = useState<SettingsType | null>(null);
   const [connectedPlatforms, setConnectedPlatforms] = useState<{ platform: Platform; username: string }[]>([]);
+  const aiSupported = isSummarizerSupported();
 
   // DeployHQ state
   const [dhqAccount, setDhqAccount] = useState<DeployHQAccount | null>(null);
@@ -224,6 +226,18 @@ export default function Settings({ onNavigate, theme, onThemeChange }: SettingsP
           </select>
         </SettingRow>
       </Section>
+
+      {/* AI — only where Chrome's built-in Summarizer API is available */}
+      {aiSupported && (
+        <Section title="AI">
+          <SettingRow
+            label="Enable AI features"
+            description="Adds a short TL;DR under each PR and a digest of unresolved review threads. Runs locally in Chrome — nothing leaves your browser. Downloads a model on first use."
+          >
+            <Toggle checked={settings.aiEnabled} onChange={(v) => handleToggle('aiEnabled', v)} label="Enable AI features" />
+          </SettingRow>
+        </Section>
+      )}
 
       {/* Polling */}
       <Section title="Polling">
@@ -477,8 +491,8 @@ function SettingRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex items-center justify-between py-2.5 border-b border-gray-200 dark:border-gray-800">
-      <div>
+    <div className="flex items-center justify-between gap-3 py-2.5 border-b border-gray-200 dark:border-gray-800">
+      <div className="min-w-0">
         <div className="text-[13px] text-gray-800 dark:text-gray-200">{label}</div>
         {description && <div className="text-[11px] text-gray-500 mt-0.5">{description}</div>}
       </div>
@@ -500,7 +514,7 @@ function Toggle({ checked, onChange, label }: { checked: boolean; onChange: (v: 
       aria-checked={checked}
       aria-label={label}
       onClick={() => onChange(!checked)}
-      className={`relative w-9 h-5 rounded-full transition-colors ${
+      className={`relative flex-shrink-0 w-9 h-5 rounded-full transition-colors ${
         checked ? 'bg-radar-600' : 'bg-gray-300 dark:bg-gray-700'
       }`}
     >

--- a/src/shared/ai/summarizer-api.d.ts
+++ b/src/shared/ai/summarizer-api.d.ts
@@ -1,0 +1,44 @@
+// Minimal ambient types for Chrome's built-in Summarizer API (Gemini Nano,
+// on-device). Stable in Chrome 138+ including the extensions context. Not yet
+// part of the TS DOM lib, so we declare the slice we use.
+// https://developer.chrome.com/docs/ai/summarizer-api
+
+type SummarizerAvailability = 'unavailable' | 'downloadable' | 'downloading' | 'available';
+
+interface SummarizerCreateOptions {
+  type?: 'tldr' | 'key-points' | 'teaser' | 'headline';
+  format?: 'plain-text' | 'markdown';
+  length?: 'short' | 'medium' | 'long';
+  sharedContext?: string;
+  // BCP-47 codes. Chrome warns when output language is unspecified; setting it
+  // also attests output safety. Supported set is currently ['en', 'es', 'ja'].
+  outputLanguage?: string;
+  expectedInputLanguages?: string[];
+  monitor?: (monitor: SummarizerMonitor) => void;
+}
+
+interface SummarizerMonitor extends EventTarget {
+  addEventListener(
+    type: 'downloadprogress',
+    listener: (event: { loaded: number }) => void,
+  ): void;
+}
+
+interface SummarizerSummarizeOptions {
+  context?: string;
+}
+
+// Instance type.
+interface Summarizer {
+  summarize(input: string, options?: SummarizerSummarizeOptions): Promise<string>;
+  destroy(): void;
+}
+
+interface SummarizerFactory {
+  availability(options?: Partial<SummarizerCreateOptions>): Promise<SummarizerAvailability>;
+  create(options?: SummarizerCreateOptions): Promise<Summarizer>;
+}
+
+// Global value — `undefined` on browsers/contexts without the API, so callers
+// must feature-detect with `typeof Summarizer !== 'undefined'`.
+declare const Summarizer: SummarizerFactory | undefined;

--- a/src/shared/ai/summarizer.ts
+++ b/src/shared/ai/summarizer.ts
@@ -81,6 +81,24 @@ async function writeCached(key: string, summary: string): Promise<void> {
   await chrome.storage.local.set({ [AI_SUMMARY_CACHE_KEY]: cache });
 }
 
+const TLDR_OPTIONS: SummarizerCreateOptions = {
+  type: 'tldr',
+  format: 'plain-text',
+  length: 'short',
+  outputLanguage: OUTPUT_LANGUAGE,
+  sharedContext:
+    'Concise, factual one-line summaries of pull request descriptions for a developer dashboard.',
+};
+
+const KEY_POINTS_OPTIONS: SummarizerCreateOptions = {
+  type: 'key-points',
+  format: 'markdown',
+  length: 'short',
+  outputLanguage: OUTPUT_LANGUAGE,
+  sharedContext:
+    'Unresolved code-review comments on a pull request. Summarize what reviewers are asking for as a short bullet list of concrete action items.',
+};
+
 // Sessions are reused across PRs (cheaper than create/destroy per row) and kept
 // per config — the TL;DR and key-points modes need different create options.
 const sessions = new Map<string, Promise<Summarizer>>();
@@ -109,6 +127,23 @@ function runQueued<T>(task: () => Promise<T>): Promise<T> {
   return run;
 }
 
+// Create the on-device session (downloading the model if needed) from within a
+// user gesture. Chrome requires a transient user activation for
+// Summarizer.create() when the model still needs downloading — so calling these
+// synchronously from a click/toggle handler captures that activation, and later
+// async paths (mount effects, post-fetch callbacks) reuse the cached session
+// without a NotAllowedError. Fire-and-forget; failures are swallowed and simply
+// leave the session to be retried later.
+export function prewarmSummary(): void {
+  if (!isSummarizerSupported()) return;
+  void getSession('tldr', TLDR_OPTIONS).catch(() => undefined);
+}
+
+export function prewarmThreadSummary(): void {
+  if (!isSummarizerSupported()) return;
+  void getSession('key-points', KEY_POINTS_OPTIONS).catch(() => undefined);
+}
+
 /** 'unavailable' | 'downloadable' | 'downloading' | 'available'. */
 export async function summarizerAvailability(): Promise<SummarizerAvailability> {
   if (!isSummarizerSupported()) return 'unavailable';
@@ -130,14 +165,7 @@ export async function generateSummary(
   if (!text) return '';
 
   const summary = await runQueued(async () => {
-    const session = await getSession('tldr', {
-      type: 'tldr',
-      format: 'plain-text',
-      length: 'short',
-      outputLanguage: OUTPUT_LANGUAGE,
-      sharedContext:
-        'Concise, factual one-line summaries of pull request descriptions for a developer dashboard.',
-    });
+    const session = await getSession('tldr', TLDR_OPTIONS);
     return (await session.summarize(text)).trim();
   });
 
@@ -165,14 +193,7 @@ export async function generateThreadSummary(
   if (!text) return '';
 
   const summary = await runQueued(async () => {
-    const session = await getSession('key-points', {
-      type: 'key-points',
-      format: 'markdown',
-      length: 'short',
-      outputLanguage: OUTPUT_LANGUAGE,
-      sharedContext:
-        'Unresolved code-review comments on a pull request. Summarize what reviewers are asking for as a short bullet list of concrete action items.',
-    });
+    const session = await getSession('key-points', KEY_POINTS_OPTIONS);
     return (await session.summarize(text)).trim();
   });
 

--- a/src/shared/ai/summarizer.ts
+++ b/src/shared/ai/summarizer.ts
@@ -41,7 +41,9 @@ export function isSummarizerSupported(): boolean {
  * invalidates the old summary; falls back to a hash of the description.
  */
 export function summaryCacheKey(pr: Pick<PullRequest, 'id' | 'headSha' | 'description'>): string {
-  const version = pr.headSha || hashString(pr.description ?? '');
+  // Include the description hash even when headSha is present, so editing a PR
+  // description without pushing code still invalidates the cached TL;DR.
+  const version = `${pr.headSha || '?'}:${hashString(pr.description ?? '')}`;
   return `${pr.id}@${version}`;
 }
 

--- a/src/shared/ai/summarizer.ts
+++ b/src/shared/ai/summarizer.ts
@@ -1,0 +1,190 @@
+// On-device summaries via Chrome's built-in Summarizer API.
+//
+//   - TL;DR of a PR description (generateSummary)
+//   - "What's blocking this" digest of unresolved review threads
+//     (generateThreadSummary)
+//
+// Everything here is a progressive enhancement: the API only exists on capable
+// Chrome installs (≥138, sufficient hardware, model downloaded). Callers must
+// gate on isSummarizerSupported() — on Firefox, Edge, or unsupported hardware
+// the global is absent and these helpers no-op.
+//
+// Summaries run entirely locally; no PR content leaves the browser.
+
+import type { PullRequest, UnresolvedThread } from '../types';
+
+export const AI_SUMMARY_CACHE_KEY = 'pr_radar_ai_summaries';
+
+// Output language: Chrome warns (and degrades safety attestation) when this is
+// unset. Supported set is currently ['en', 'es', 'ja'].
+const OUTPUT_LANGUAGE = 'en';
+// Cap how much text we feed the model — keeps latency bounded and avoids
+// overrunning the model's context on very long inputs.
+const MAX_INPUT_CHARS = 4000;
+// Bound the stored cache so it can't grow without limit across many repos.
+const CACHE_LIMIT = 300;
+
+interface CachedSummary {
+  summary: string;
+  createdAt: number;
+}
+
+type SummaryCache = Record<string, CachedSummary>;
+
+/** True only where Chrome exposes the built-in Summarizer API. */
+export function isSummarizerSupported(): boolean {
+  return typeof Summarizer !== 'undefined';
+}
+
+/**
+ * Cache key for a PR's description TL;DR. Tied to headSha so a new push
+ * invalidates the old summary; falls back to a hash of the description.
+ */
+export function summaryCacheKey(pr: Pick<PullRequest, 'id' | 'headSha' | 'description'>): string {
+  const version = pr.headSha || hashString(pr.description ?? '');
+  return `${pr.id}@${version}`;
+}
+
+/**
+ * Cache key for a PR's unresolved-thread digest. Keyed on headSha and the
+ * unresolved count so it regenerates when code is pushed or threads are
+ * added/resolved.
+ */
+export function threadSummaryCacheKey(
+  pr: Pick<PullRequest, 'id' | 'headSha' | 'unresolvedCommentCount'>,
+): string {
+  return `thread:${pr.id}@${pr.headSha || '?'}#${pr.unresolvedCommentCount}`;
+}
+
+async function readCache(): Promise<SummaryCache> {
+  const result = await chrome.storage.local.get(AI_SUMMARY_CACHE_KEY);
+  return result[AI_SUMMARY_CACHE_KEY] ?? {};
+}
+
+export async function getCachedSummary(key: string): Promise<string | null> {
+  const cache = await readCache();
+  return cache[key]?.summary ?? null;
+}
+
+async function writeCached(key: string, summary: string): Promise<void> {
+  const cache = await readCache();
+  cache[key] = { summary, createdAt: Date.now() };
+
+  const keys = Object.keys(cache);
+  if (keys.length > CACHE_LIMIT) {
+    // Drop the oldest entries down to the limit.
+    const sorted = keys.sort((a, b) => cache[a].createdAt - cache[b].createdAt);
+    for (const stale of sorted.slice(0, keys.length - CACHE_LIMIT)) {
+      delete cache[stale];
+    }
+  }
+  await chrome.storage.local.set({ [AI_SUMMARY_CACHE_KEY]: cache });
+}
+
+// Sessions are reused across PRs (cheaper than create/destroy per row) and kept
+// per config — the TL;DR and key-points modes need different create options.
+const sessions = new Map<string, Promise<Summarizer>>();
+// Serialize summarize() calls across all sessions; the on-device model serves
+// requests sequentially, and a stampede on dashboard open would just thrash it.
+let queue: Promise<unknown> = Promise.resolve();
+
+function getSession(key: string, options: SummarizerCreateOptions): Promise<Summarizer> {
+  let session = sessions.get(key);
+  if (!session) {
+    // typeof guard in isSummarizerSupported() — callers must check first.
+    session = Summarizer!.create(options).catch((err) => {
+      // Reset so a later call can retry (e.g. transient download failure).
+      sessions.delete(key);
+      throw err;
+    });
+    sessions.set(key, session);
+  }
+  return session;
+}
+
+function runQueued<T>(task: () => Promise<T>): Promise<T> {
+  const run = queue.then(task);
+  // Keep the chain alive even if this run rejects.
+  queue = run.catch(() => undefined);
+  return run;
+}
+
+/** 'unavailable' | 'downloadable' | 'downloading' | 'available'. */
+export async function summarizerAvailability(): Promise<SummarizerAvailability> {
+  if (!isSummarizerSupported()) return 'unavailable';
+  return Summarizer!.availability({ type: 'tldr', format: 'plain-text', length: 'short', outputLanguage: OUTPUT_LANGUAGE });
+}
+
+/**
+ * One-line TL;DR for a PR, cache-first. Returns '' when there's no meaningful
+ * description. Throws if the model is unavailable — callers degrade silently.
+ */
+export async function generateSummary(
+  pr: Pick<PullRequest, 'id' | 'headSha' | 'description'>,
+): Promise<string> {
+  const key = summaryCacheKey(pr);
+  const cached = await getCachedSummary(key);
+  if (cached !== null) return cached;
+
+  const text = (pr.description ?? '').trim().slice(0, MAX_INPUT_CHARS);
+  if (!text) return '';
+
+  const summary = await runQueued(async () => {
+    const session = await getSession('tldr', {
+      type: 'tldr',
+      format: 'plain-text',
+      length: 'short',
+      outputLanguage: OUTPUT_LANGUAGE,
+      sharedContext:
+        'Concise, factual one-line summaries of pull request descriptions for a developer dashboard.',
+    });
+    return (await session.summarize(text)).trim();
+  });
+
+  if (summary) await writeCached(key, summary);
+  return summary;
+}
+
+/**
+ * Key-points digest of a PR's unresolved review threads ("what's blocking
+ * this"), cache-first. Returns '' when there's nothing to summarize. Throws if
+ * the model is unavailable — callers degrade silently.
+ */
+export async function generateThreadSummary(
+  cacheKey: string,
+  threads: UnresolvedThread[],
+): Promise<string> {
+  const cached = await getCachedSummary(cacheKey);
+  if (cached !== null) return cached;
+
+  const text = threads
+    .map((t) => `${t.author}${t.path ? ` on ${t.path}` : ''}: ${t.body}`)
+    .join('\n\n')
+    .trim()
+    .slice(0, MAX_INPUT_CHARS);
+  if (!text) return '';
+
+  const summary = await runQueued(async () => {
+    const session = await getSession('key-points', {
+      type: 'key-points',
+      format: 'markdown',
+      length: 'short',
+      outputLanguage: OUTPUT_LANGUAGE,
+      sharedContext:
+        'Unresolved code-review comments on a pull request. Summarize what reviewers are asking for as a short bullet list of concrete action items.',
+    });
+    return (await session.summarize(text)).trim();
+  });
+
+  if (summary) await writeCached(cacheKey, summary);
+  return summary;
+}
+
+// Small, stable string hash (djb2) for cache-key versioning.
+function hashString(input: string): string {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36);
+}

--- a/src/shared/api/bitbucket.test.ts
+++ b/src/shared/api/bitbucket.test.ts
@@ -5,6 +5,7 @@ import {
   checkIfMerged,
   mergePullRequest,
   fetchPullRequests,
+  fetchUnresolvedThreads,
 } from './bitbucket';
 
 // === Pure function tests ===
@@ -314,6 +315,57 @@ describe('fetchPullRequests', () => {
 });
 
 // === Helpers ===
+
+describe('fetchUnresolvedThreads', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns unresolved inline comments, skipping non-inline/resolved/empty', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(bbJsonResponse({
+      values: [
+        { id: 1, inline: { path: 'src/a.ts' }, resolved: false, content: { raw: 'fix this' }, user: { display_name: 'Alice', nickname: 'alice' } },
+        { id: 2, inline: { path: 'src/a.ts' }, resolved: true, content: { raw: 'done' }, user: { display_name: 'Bob', nickname: 'bob' } },
+        { id: 3, content: { raw: 'general (not inline)' }, user: { display_name: 'Carol', nickname: 'carol' } },
+        { id: 4, inline: { path: 'src/b.ts' }, resolved: false, content: { raw: '  ' }, user: { display_name: 'Dave', nickname: 'dave' } },
+      ],
+    }));
+
+    const threads = await fetchUnresolvedThreads('token', 'team/repo', 7);
+
+    expect(threads).toEqual([{ author: 'Alice', body: 'fix this', path: 'src/a.ts' }]);
+  });
+
+  it('paginates comments when a next link is present', async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(bbJsonResponse({
+        values: [{ id: 1, inline: { path: 'a.ts' }, resolved: false, content: { raw: 'first' }, user: { display_name: 'Alice', nickname: 'alice' } }],
+        next: 'https://api.bitbucket.org/2.0/repositories/team/repo/pullrequests/7/comments?page=2',
+      }))
+      .mockResolvedValueOnce(bbJsonResponse({
+        values: [{ id: 2, inline: { path: 'b.ts' }, resolved: false, content: { raw: 'second' }, user: { display_name: 'Bob', nickname: 'bob' } }],
+      }));
+
+    const threads = await fetchUnresolvedThreads('token', 'team/repo', 7);
+
+    expect(threads.map((t) => t.body)).toEqual(['first', 'second']);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns [] when the request fails', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new Error('network'));
+
+    const threads = await fetchUnresolvedThreads('token', 'team/repo', 7);
+
+    expect(threads).toEqual([]);
+  });
+});
 
 function bbJsonResponse(body: unknown): Response {
   return {

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -311,11 +311,13 @@ export async function fetchUnresolvedThreads(
   prId: number,
 ): Promise<UnresolvedThread[]> {
   try {
-    const result = await bbFetch<{ values: BBComment[] }>(
+    // Paginate — a PR can have >100 comments, and a partial fetch silently
+    // drops unresolved threads from the digest.
+    const comments = await bbFetchPaginated<BBComment>(
       `/repositories/${repoFullName}/pullrequests/${prId}/comments?pagelen=100`,
       token,
     );
-    return result.values
+    return comments
       .filter((c) => c.inline && !c.resolved && c.content?.raw?.trim())
       .map((c) => ({
         author: c.user?.display_name || c.user?.nickname || 'someone',

--- a/src/shared/api/bitbucket.ts
+++ b/src/shared/api/bitbucket.ts
@@ -1,4 +1,4 @@
-import type { PullRequest, CIStatus, ReviewStatus } from '../types';
+import type { PullRequest, CIStatus, ReviewStatus, UnresolvedThread } from '../types';
 
 const BASE_URL = 'https://api.bitbucket.org/2.0';
 
@@ -301,6 +301,29 @@ async function fetchCIStatus(token: string, repoFullName: string, pr: BBPullRequ
     }
   } catch {
     return { status: 'unknown' };
+  }
+}
+
+// On-demand bodies of unresolved inline comments for thread summarization.
+export async function fetchUnresolvedThreads(
+  token: string,
+  repoFullName: string,
+  prId: number,
+): Promise<UnresolvedThread[]> {
+  try {
+    const result = await bbFetch<{ values: BBComment[] }>(
+      `/repositories/${repoFullName}/pullrequests/${prId}/comments?pagelen=100`,
+      token,
+    );
+    return result.values
+      .filter((c) => c.inline && !c.resolved && c.content?.raw?.trim())
+      .map((c) => ({
+        author: c.user?.display_name || c.user?.nickname || 'someone',
+        body: c.content.raw.trim(),
+        path: c.inline?.path,
+      }));
+  } catch {
+    return [];
   }
 }
 

--- a/src/shared/api/github.test.ts
+++ b/src/shared/api/github.test.ts
@@ -5,6 +5,7 @@ import {
   getNextPagePath,
   getUserRepos,
   mapWithConcurrencyLimit,
+  fetchUnresolvedThreads,
   type GHReview,
 } from './github';
 
@@ -176,6 +177,75 @@ describe('getUserRepos', () => {
       { full_name: 'deployhq/launch' },
     ]);
     expect(fetchMock).toHaveBeenCalledTimes(6);
+  });
+});
+
+describe('fetchUnresolvedThreads', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function threadsResponse(
+    nodes: unknown[],
+    hasNextPage = false,
+    endCursor: string | null = null,
+  ): Response {
+    return jsonResponse({
+      data: { repository: { pullRequest: { reviewThreads: { pageInfo: { hasNextPage, endCursor }, nodes } } } },
+    });
+  }
+
+  it('returns unresolved threads, skipping resolved and empty-body ones', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(threadsResponse([
+      { isResolved: false, path: 'src/a.ts', comments: { nodes: [{ author: { login: 'alice' }, body: 'add a test' }] } },
+      { isResolved: true, path: 'src/b.ts', comments: { nodes: [{ author: { login: 'bob' }, body: 'already resolved' }] } },
+      { isResolved: false, path: 'src/c.ts', comments: { nodes: [{ author: { login: 'carol' }, body: '   ' }] } },
+    ]));
+
+    const threads = await fetchUnresolvedThreads('token', 'owner/repo', 1);
+
+    expect(threads).toEqual([{ author: 'alice', body: 'add a test', path: 'src/a.ts' }]);
+  });
+
+  it('falls back to "someone" when the comment has no author', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(threadsResponse([
+      { isResolved: false, path: 'src/a.ts', comments: { nodes: [{ body: 'ghost comment' }] } },
+    ]));
+
+    const threads = await fetchUnresolvedThreads('token', 'owner/repo', 1);
+
+    expect(threads).toEqual([{ author: 'someone', body: 'ghost comment', path: 'src/a.ts' }]);
+  });
+
+  it('paginates across review-thread pages', async () => {
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(threadsResponse(
+        [{ isResolved: false, path: 'a.ts', comments: { nodes: [{ author: { login: 'alice' }, body: 'first' }] } }],
+        true,
+        'CURSOR1',
+      ))
+      .mockResolvedValueOnce(threadsResponse(
+        [{ isResolved: false, path: 'b.ts', comments: { nodes: [{ author: { login: 'bob' }, body: 'second' }] } }],
+      ));
+
+    const threads = await fetchUnresolvedThreads('token', 'owner/repo', 1);
+
+    expect(threads.map((t) => t.body)).toEqual(['first', 'second']);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns [] when the request fails', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce({ ok: false, status: 500 } as Response);
+
+    const threads = await fetchUnresolvedThreads('token', 'owner/repo', 1);
+
+    expect(threads).toEqual([]);
   });
 });
 

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -584,6 +584,19 @@ async function ghGraphQL<T>(token: string, query: string, variables: Record<stri
   return data.data ?? null;
 }
 
+interface ReviewThreadPage {
+  pageInfo?: { hasNextPage?: boolean; endCursor?: string | null };
+  nodes?: Array<{
+    isResolved: boolean;
+    path?: string;
+    comments?: { nodes?: Array<{ author?: { login: string }; body?: string }> };
+  }>;
+}
+
+interface UnresolvedThreadsData {
+  repository?: { pullRequest?: { reviewThreads?: ReviewThreadPage } };
+}
+
 // On-demand: the leading comment of each unresolved review thread, with body
 // text (the polling path only counts threads, it doesn't keep bodies).
 export async function fetchUnresolvedThreads(
@@ -592,10 +605,11 @@ export async function fetchUnresolvedThreads(
   prNumber: number,
 ): Promise<UnresolvedThread[]> {
   const [owner, repo] = repoFullName.split('/');
-  const query = `query UnresolvedThreads($owner: String!, $repo: String!, $prNumber: Int!) {
+  const query = `query UnresolvedThreads($owner: String!, $repo: String!, $prNumber: Int!, $after: String) {
     repository(owner: $owner, name: $repo) {
       pullRequest(number: $prNumber) {
-        reviewThreads(first: 100) {
+        reviewThreads(first: 100, after: $after) {
+          pageInfo { hasNextPage endCursor }
           nodes {
             isResolved
             path
@@ -607,23 +621,34 @@ export async function fetchUnresolvedThreads(
   }`;
 
   try {
-    const data = await ghGraphQL<{
-      repository?: { pullRequest?: { reviewThreads?: { nodes?: Array<{
-        isResolved: boolean;
-        path?: string;
-        comments?: { nodes?: Array<{ author?: { login: string }; body?: string }> };
-      }> } } };
-    }>(token, query, { owner, repo, prNumber });
-
-    const nodes = data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
     const threads: UnresolvedThread[] = [];
-    for (const node of nodes) {
-      if (node.isResolved) continue;
-      const comment = node.comments?.nodes?.[0];
-      const body = comment?.body?.trim();
-      if (!body) continue;
-      threads.push({ author: comment?.author?.login ?? 'someone', body, path: node.path });
+    let after: string | null = null;
+    let pageCount = 0;
+
+    // Paginate — large PRs can exceed 100 review threads, and a single page
+    // would silently drop the rest from the digest.
+    while (pageCount < MAX_PAGINATED_PAGES) {
+      const data: UnresolvedThreadsData | null = await ghGraphQL<UnresolvedThreadsData>(
+        token,
+        query,
+        { owner, repo, prNumber, after },
+      );
+
+      const threadPage: ReviewThreadPage | undefined = data?.repository?.pullRequest?.reviewThreads;
+      for (const node of threadPage?.nodes ?? []) {
+        if (node.isResolved) continue;
+        const comment = node.comments?.nodes?.[0];
+        const body = comment?.body?.trim();
+        if (!body) continue;
+        threads.push({ author: comment?.author?.login ?? 'someone', body, path: node.path });
+      }
+
+      const pageInfo: ReviewThreadPage['pageInfo'] = threadPage?.pageInfo;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+      after = pageInfo.endCursor;
+      pageCount += 1;
     }
+
     return threads;
   } catch {
     return [];

--- a/src/shared/api/github.ts
+++ b/src/shared/api/github.ts
@@ -1,4 +1,4 @@
-import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo } from '../types';
+import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo, UnresolvedThread } from '../types';
 
 const BASE_URL = 'https://api.github.com';
 const HYDRATE_CONCURRENCY = 5;
@@ -582,6 +582,52 @@ async function ghGraphQL<T>(token: string, query: string, variables: Record<stri
 
   const data = await res.json() as GraphQLResponse<T>;
   return data.data ?? null;
+}
+
+// On-demand: the leading comment of each unresolved review thread, with body
+// text (the polling path only counts threads, it doesn't keep bodies).
+export async function fetchUnresolvedThreads(
+  token: string,
+  repoFullName: string,
+  prNumber: number,
+): Promise<UnresolvedThread[]> {
+  const [owner, repo] = repoFullName.split('/');
+  const query = `query UnresolvedThreads($owner: String!, $repo: String!, $prNumber: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $prNumber) {
+        reviewThreads(first: 100) {
+          nodes {
+            isResolved
+            path
+            comments(first: 1) { nodes { author { login } body } }
+          }
+        }
+      }
+    }
+  }`;
+
+  try {
+    const data = await ghGraphQL<{
+      repository?: { pullRequest?: { reviewThreads?: { nodes?: Array<{
+        isResolved: boolean;
+        path?: string;
+        comments?: { nodes?: Array<{ author?: { login: string }; body?: string }> };
+      }> } } };
+    }>(token, query, { owner, repo, prNumber });
+
+    const nodes = data?.repository?.pullRequest?.reviewThreads?.nodes ?? [];
+    const threads: UnresolvedThread[] = [];
+    for (const node of nodes) {
+      if (node.isResolved) continue;
+      const comment = node.comments?.nodes?.[0];
+      const body = comment?.body?.trim();
+      if (!body) continue;
+      threads.push({ author: comment?.author?.login ?? 'someone', body, path: node.path });
+    }
+    return threads;
+  } catch {
+    return [];
+  }
 }
 
 async function fetchGraphQLDetails(token: string, repoFullName: string, prNumber: number): Promise<GraphQLPRDetails> {

--- a/src/shared/api/gitlab.test.ts
+++ b/src/shared/api/gitlab.test.ts
@@ -6,6 +6,7 @@ import {
   fetchMergeRequests,
   checkIfMerged,
   mergeMergeRequest,
+  fetchUnresolvedThreads,
 } from './gitlab';
 
 // === Pure function tests ===
@@ -232,6 +233,55 @@ describe('mergeMergeRequest', () => {
 });
 
 // === Helpers ===
+
+describe('fetchUnresolvedThreads', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it('returns unresolved notes, skipping resolved/non-resolvable/empty', async () => {
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(glJsonResponse([
+      { notes: [{ resolvable: true, resolved: false, body: 'fix this', author: { username: 'alice' }, position: { new_path: 'src/a.ts' } }] },
+      { notes: [{ resolvable: true, resolved: true, body: 'done', author: { username: 'bob' } }] },
+      { notes: [{ resolvable: false, resolved: false, body: 'general comment', author: { username: 'carol' } }] },
+      { notes: [{ resolvable: true, resolved: false, body: '  ', author: { username: 'dave' } }] },
+    ]));
+
+    const threads = await fetchUnresolvedThreads('token', 'group/proj', 42);
+
+    expect(threads).toEqual([{ author: 'alice', body: 'fix this', path: 'src/a.ts' }]);
+  });
+
+  it('paginates discussions when a full page is returned', async () => {
+    const fullPage = Array.from({ length: 100 }, (_, i) => ({
+      notes: [{ resolvable: true, resolved: false, body: `note ${i}`, author: { username: 'u' } }],
+    }));
+    vi.mocked(globalThis.fetch)
+      .mockResolvedValueOnce(glJsonResponse(fullPage))
+      .mockResolvedValueOnce(glJsonResponse([
+        { notes: [{ resolvable: true, resolved: false, body: 'last', author: { username: 'z' } }] },
+      ]));
+
+    const threads = await fetchUnresolvedThreads('token', 'group/proj', 42);
+
+    expect(threads).toHaveLength(101);
+    expect(vi.mocked(globalThis.fetch)).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns [] when the request fails', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new Error('network'));
+
+    const threads = await fetchUnresolvedThreads('token', 'group/proj', 42);
+
+    expect(threads).toEqual([]);
+  });
+});
 
 function glResponse(body: unknown, nextPage: string | null): Response {
   return {

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -1,4 +1,4 @@
-import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo } from '../types';
+import type { PullRequest, CIStatus, ReviewStatus, RateLimitInfo, UnresolvedThread } from '../types';
 
 const BASE_URL = 'https://gitlab.com/api/v4';
 
@@ -174,6 +174,39 @@ export async function fetchMergeRequests(
   );
 
   return results;
+}
+
+// On-demand bodies of unresolved discussion notes for thread summarization.
+export async function fetchUnresolvedThreads(
+  token: string,
+  projectPath: string,
+  mrIid: number,
+): Promise<UnresolvedThread[]> {
+  const encodedPath = encodeURIComponent(projectPath);
+  try {
+    const discussions = await glFetch<Array<{
+      notes: Array<{
+        resolvable: boolean;
+        resolved?: boolean;
+        body?: string;
+        author: { username: string };
+        position?: { new_path?: string };
+      }>;
+    }>>(`/projects/${encodedPath}/merge_requests/${mrIid}/discussions`, token);
+
+    const threads: UnresolvedThread[] = [];
+    for (const discussion of discussions) {
+      for (const note of discussion.notes) {
+        if (!note.resolvable || note.resolved) continue;
+        const body = note.body?.trim();
+        if (!body) continue;
+        threads.push({ author: note.author.username, body, path: note.position?.new_path });
+      }
+    }
+    return threads;
+  } catch {
+    return [];
+  }
 }
 
 async function hydrateMR(

--- a/src/shared/api/gitlab.ts
+++ b/src/shared/api/gitlab.ts
@@ -184,7 +184,7 @@ export async function fetchUnresolvedThreads(
 ): Promise<UnresolvedThread[]> {
   const encodedPath = encodeURIComponent(projectPath);
   try {
-    const discussions = await glFetch<Array<{
+    type GLDiscussionNotes = {
       notes: Array<{
         resolvable: boolean;
         resolved?: boolean;
@@ -192,7 +192,22 @@ export async function fetchUnresolvedThreads(
         author: { username: string };
         position?: { new_path?: string };
       }>;
-    }>>(`/projects/${encodedPath}/merge_requests/${mrIid}/discussions`, token);
+    };
+
+    // The discussions endpoint defaults to 20 per page — paginate so MRs with
+    // many threads don't silently drop unresolved notes.
+    const discussions: GLDiscussionNotes[] = [];
+    let page = 1;
+    const maxPages = 10;
+    while (page <= maxPages) {
+      const batch = await glFetch<GLDiscussionNotes[]>(
+        `/projects/${encodedPath}/merge_requests/${mrIid}/discussions?per_page=100&page=${page}`,
+        token,
+      );
+      discussions.push(...batch);
+      if (batch.length < 100) break;
+      page++;
+    }
 
     const threads: UnresolvedThread[] = [];
     for (const discussion of discussions) {

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -193,6 +193,7 @@ export async function dismissRateLimitWarning(): Promise<void> {
 
 const INSTALL_DATE_KEY = 'pr_radar_install_date';
 const STAR_PROMPT_DISMISSED_KEY = 'pr_radar_star_dismissed';
+const WHATS_NEW_SEEN_VERSION_KEY = 'pr_radar_whats_new_seen_version';
 
 export async function clearAll(): Promise<void> {
   await chrome.storage.local.remove([
@@ -202,6 +203,7 @@ export async function clearAll(): Promise<void> {
     PR_CACHE_KEY,
     INSTALL_DATE_KEY,
     STAR_PROMPT_DISMISSED_KEY,
+    WHATS_NEW_SEEN_VERSION_KEY,
     DEPLOYHQ_ACCOUNT_KEY,
     DEPLOYHQ_MAPPING_KEY,
     POLL_ERRORS_KEY,
@@ -231,4 +233,18 @@ export async function isStarPromptDismissed(): Promise<boolean> {
 
 export async function dismissStarPrompt(): Promise<void> {
   await chrome.storage.local.set({ [STAR_PROMPT_DISMISSED_KEY]: true });
+}
+
+// === What's-new banner ===
+// The version the user last acknowledged. The banner shows when this differs
+// from the running extension version; fresh installs are stamped with the
+// current version so new users never see "what's new" for the release they
+// installed at.
+export async function getWhatsNewSeenVersion(): Promise<string | null> {
+  const result = await chrome.storage.local.get(WHATS_NEW_SEEN_VERSION_KEY);
+  return result[WHATS_NEW_SEEN_VERSION_KEY] ?? null;
+}
+
+export async function setWhatsNewSeenVersion(version: string): Promise<void> {
+  await chrome.storage.local.set({ [WHATS_NEW_SEEN_VERSION_KEY]: version });
 }

--- a/src/shared/storage.ts
+++ b/src/shared/storage.ts
@@ -1,5 +1,6 @@
 import type { PlatformAccount, WatchedRepo, Platform, DeployHQAccount, PollError, RateLimitInfo, DashboardTab, SortMode } from './types';
 import type { SoundId } from './constants';
+import { AI_SUMMARY_CACHE_KEY } from './ai/summarizer';
 
 const ACCOUNTS_KEY = 'pr_radar_accounts';
 const SETTINGS_KEY = 'pr_radar_settings';
@@ -26,6 +27,10 @@ export interface Settings {
   theme: ThemeMode;
   lastTab: DashboardTab;
   sortMode: SortMode;
+  // Master switch for on-device AI features (Chrome built-in Summarizer):
+  // PR TL;DRs and unresolved-thread digests. Opt-in; only takes effect where
+  // the Summarizer API is available.
+  aiEnabled: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -41,6 +46,7 @@ const DEFAULT_SETTINGS: Settings = {
   theme: 'system',
   lastTab: 'mine',
   sortMode: 'default',
+  aiEnabled: false,
 };
 
 export async function getSettings(): Promise<Settings> {
@@ -202,6 +208,7 @@ export async function clearAll(): Promise<void> {
     RATE_LIMITS_KEY,
     POLL_ERRORS_DISMISSED_KEY,
     RATE_LIMIT_DISMISSED_KEY,
+    AI_SUMMARY_CACHE_KEY,
   ]);
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -70,6 +70,14 @@ export interface PullRequest {
   };
 }
 
+// An unresolved review thread's leading comment, fetched on demand for
+// on-device summarization. Platform-agnostic shape.
+export interface UnresolvedThread {
+  author: string;
+  body: string;
+  path?: string; // file path for inline comments, when available
+}
+
 // === DeployHQ ===
 
 export interface DeployHQAccount {
@@ -164,4 +172,5 @@ export type Message =
   | { type: 'DELETE_BRANCH'; payload: { platform: Platform; repoFullName: string; branch: string } }
   | { type: 'TEST_DEPLOYHQ'; payload: { slug: string; email: string; apiKey: string } }
   | { type: 'GET_DEPLOYHQ_SERVERS'; payload: { repoFullName: string } }
-  | { type: 'CREATE_DEPLOYHQ_DEPLOYMENT'; payload: { repoFullName: string; serverIdentifier: string } };
+  | { type: 'CREATE_DEPLOYHQ_DEPLOYMENT'; payload: { repoFullName: string; serverIdentifier: string } }
+  | { type: 'GET_PR_THREADS'; payload: { platform: Platform; repoFullName: string; prNumber: number } };


### PR DESCRIPTION
## Summary

Adds opt-in AI features powered by Chrome's **built-in Summarizer API** (Gemini Nano). Everything runs **locally on-device** — no PR content leaves the browser, no backend, no API keys. Consistent with PR Radar's privacy-first, no-backend design.

Two features, both behind a single **"Enable AI features"** toggle in Settings:

1. **PR description TL;DR** — a one-line on-device summary under each PR (clamped to two lines, full text on hover).
2. **Unresolved-thread digest** — click the 💬 comment badge to fetch the unresolved review threads on demand and summarize what reviewers are asking for as a key-points list.

Plus a version-gated **"what's new" banner** that surfaces the features to users who update in (fresh installs are excluded).

## How it works

- **Feature-detected** via `typeof Summarizer` — degrades to nothing on Firefox, Edge, and unsupported hardware (the Settings section is hidden entirely there). Nothing core depends on it.
- **On-demand thread fetch** — comment bodies are only fetched when a badge is expanded, so regular polling cost is unchanged.
- **Cached** in `chrome.storage`, keyed by `headSha` (+ unresolved count for threads), so summaries are instant on reopen and regenerate when code is pushed.
- **`outputLanguage: 'en'`** set to satisfy Chrome's output-safety attestation (silences the API warning).

## Changes

- `src/shared/ai/` — new summarizer util + ambient API types (session registry, serial queue, capped cache)
- `src/shared/api/{github,gitlab,bitbucket}.ts` — `fetchUnresolvedThreads` per platform
- `src/background/service-worker.ts` — `GET_PR_THREADS` handler; stamp install version for what's-new gating
- `src/popup/{Settings,Dashboard,PRItem}` — single toggle, `✨` TL;DR line, expandable digest, what's-new banner
- `src/shared/{types,storage}.ts` — `UnresolvedThread`, `aiEnabled` setting, message type, what's-new-version helpers

## Verification

- ✅ typecheck, lint, production build (chrome)
- ✅ 85 existing API unit tests pass
- ✅ Manually verified in Chrome 149: both features generate real summaries, cache works, toggle gates correctly

## Follow-ups (not in this PR)

- Unit tests for the three `fetchUnresolvedThreads` fetchers
- First-run model-download progress indicator
- Possible #3: on-device translation of foreign-language PRs/comments

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-device AI PR TL;DR and AI-generated unresolved thread summaries when enabled (with progressive enhancement and caching).
  * Added a version-gated “What’s new” banner, plus a settings-driven AI features toggle.
* **Enhancements**
  * Unresolved comment badge becomes a “summarize threads” control when thread summarization is available.
  * Added cross-provider unresolved-thread fetching to power the summaries.
* **Bug Fixes**
  * “What’s new” tracking now updates only for brand-new installs.
* **Tests**
  * Added coverage for unresolved-thread fetching across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->