### PR TITLE
fix: correct Firefox Add-ons URL slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,14 +29,14 @@ technologies:
 
 [![GitHub stars](https://img.shields.io/github/stars/deployhq/pr-radar?style=social)](https://github.com/deployhq/pr-radar)
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/users/hkombgibegjffiadmekpiabdakkoidmh?label=Chrome%20users)](https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh)
-[![Firefox Add-on](https://img.shields.io/amo/users/pr-radar?label=Firefox%20users)](https://addons.mozilla.org/en-US/firefox/addon/pr-radar/)
+[![Firefox Add-on](https://img.shields.io/amo/users/pr-radar-by-deployhq?label=Firefox%20users)](https://addons.mozilla.org/en-US/firefox/addon/pr-radar-by-deployhq/)
 [![License: MIT](https://img.shields.io/github/license/deployhq/pr-radar)](LICENSE)
 
 **One dashboard for every pull request across GitHub, GitLab, and Bitbucket.** CI status, code reviews, deployments, and notifications — right from your browser toolbar. No tab required.
 
 <p>
   <a href="https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh"><img src="https://img.shields.io/badge/Install_for_Chrome-4285F4?style=for-the-badge&logo=googlechrome&logoColor=white" alt="Install for Chrome" /></a>
-  <a href="https://addons.mozilla.org/en-US/firefox/addon/pr-radar/"><img src="https://img.shields.io/badge/Install_for_Firefox-FF7139?style=for-the-badge&logo=firefoxbrowser&logoColor=white" alt="Install for Firefox" /></a>
+  <a href="https://addons.mozilla.org/en-US/firefox/addon/pr-radar-by-deployhq/"><img src="https://img.shields.io/badge/Install_for_Firefox-FF7139?style=for-the-badge&logo=firefoxbrowser&logoColor=white" alt="Install for Firefox" /></a>
   <a href="https://microsoftedge.microsoft.com/addons/detail/pr-radar-pr-dashboard-/angljeebomgmgepfiglbedjljgjnenhl"><img src="https://img.shields.io/badge/Install_for_Edge-0078D4?style=for-the-badge&logo=microsoftedge&logoColor=white" alt="Install for Edge" /></a>
 </p>
 
@@ -79,7 +79,7 @@ Free and open source, by [DeployHQ](https://www.deployhq.com/?utm_source=pr-rada
 
 ### Firefox
 
-[Install from Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/pr-radar/) — free, no account required.
+[Install from Firefox Add-ons](https://addons.mozilla.org/en-US/firefox/addon/pr-radar-by-deployhq/) — free, no account required.
 
 ### Edge
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -48,7 +48,7 @@ export const CHROME_WEB_STORE_URL =
   'https://chromewebstore.google.com/detail/hkombgibegjffiadmekpiabdakkoidmh';
 
 export const FIREFOX_ADDON_URL =
-  'https://addons.mozilla.org/en-US/firefox/addon/pr-radar/';
+  'https://addons.mozilla.org/en-US/firefox/addon/pr-radar-by-deployhq/';
 
 export const EDGE_ADDON_URL =
   'https://microsoftedge.microsoft.com/addons/detail/pr-radar/angljeebomgmgepfiglbedjljgjnenhl';


### PR DESCRIPTION
## Problem

The Firefox Add-ons links in the README (and the extension's in-app link) point to the wrong AMO slug — `pr-radar` — which 404s. The actual listing lives at [`pr-radar-by-deployhq`](https://addons.mozilla.org/en-US/firefox/addon/pr-radar-by-deployhq/).

Reported in #21.

## Changes

Updated all 4 references to the correct slug:

- `README.md` — Firefox users badge (shields.io `amo/users/…` image + link)
- `README.md` — "Install for Firefox" button
- `README.md` — "Install from Firefox Add-ons" text link
- `src/shared/constants.ts` — `FIREFOX_ADDON_URL` (surfaced to users in the extension UI, so it would have 404'd there too)

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Firefox-related badges and install links to point to the new Mozilla Add-ons listing.
  * Improved consistency across the app header and install section for Firefox users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->