### PR TITLE
fix: don't dim draft PRs so they're easy to spot

### DIFF
--- a/src/popup/components/PRItem.tsx
+++ b/src/popup/components/PRItem.tsx
@@ -121,7 +121,10 @@ export default function PRItem({ pr, stalePRDays, pinned, onMerged, focused, sta
   }, [pr.id, pr.headSha, pr.unresolvedCommentCount]);
   const timeAgo = getTimeAgo(pr.updatedAt);
   const isStale = stalePRDays > 0 && (Date.now() - new Date(pr.updatedAt).getTime()) > stalePRDays * 86400000;
-  const isDimmed = (pr.hasReviewed && !pr.isAuthor) || isStale || pr.isBot || pr.isMerged || pr.isDraft;
+  // Drafts are NOT dimmed: a draft is your own active work-in-progress, not a
+  // de-prioritized PR like stale/reviewed/merged ones. The ✍️ marker already
+  // flags it, and dimming made users think their drafts weren't listed (#25).
+  const isDimmed = (pr.hasReviewed && !pr.isAuthor) || isStale || pr.isBot || pr.isMerged;
   const isMergeable = !pr.isDraft && !pr.isMerged && !pr.hasConflicts && pr.ciStatus !== 'failed';
 
   async function handleMerge() {


### PR DESCRIPTION
## Why

#25 asked to "show own draft PRs." They were already listed in Mine/All — but dimmed (`opacity-50`) exactly like stale/reviewed/merged PRs, so the reporter reasonably concluded they weren't there:

> Ah, I was blind. It's grayed out like stale PRs. Maybe they could not be grayed out (or less transparent) so they're easier to spot? But they are present.

## What

Drop `pr.isDraft` from the `isDimmed` condition in `PRItem.tsx`. A draft is your own active work-in-progress — not a de-prioritized PR — and it already carries a ✍️ marker to identify it, so it doesn't need the faded treatment. A merged former-draft still dims via `pr.isMerged`.

One-line behavioral change; sort order is unchanged (out of scope for what was reported).

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run build` ✅

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)