### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "PR Radar – GitHub, GitLab & Bitbucket PRs",
   "description": "Track PRs, CI status, code reviews & deployments across GitHub, GitLab and Bitbucket. No backend, free forever. By DeployHQ.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "icons": {
     "16": "icons/icon-16.png",
     "32": "icons/icon-32.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-radar",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Track PRs, CI status, code reviews & deployments across GitHub, GitLab and Bitbucket. No backend, free forever. By DeployHQ.",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Release 0.7.0. Since 0.6.0:

**Features**
- Add a repo to watch by name — for large orgs beyond the pagination cap (#26)
- Live progress indicator while loading the repo list (#27)

**Fixes**
- Correct Firefox Add-ons URL slug (#22)
- Load watchable repos in the background and cache them; no more endless spinner (#24)
- Don't dim draft PRs so they're easy to spot (#28)

Tagging `v0.7.0` after this merges will publish to Chrome, Firefox, and Edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the extension and package version to `0.7.0`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->